### PR TITLE
Fix nalgebra being benchmarked in no-std mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ features = ["approx", "mint", "rand"]
 [dependencies.nalgebra]
 version = "~0.18"
 default-features = false
-features = ["mint"]
+features = ["std", "mint"]
 
 [dependencies.cgmath]
 version = "~0.17"


### PR DESCRIPTION
This was causing grossly misrepresentative results by forcing nalgebra to call out to libm for sqrt (for example) while other libraries were permitted to use the built-in version.