### PR TITLE
Always show batch size in wide benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-**/*.rs.bk
-**/*.swp
 .cargo
-.vim
 /target
-Session.vim
+Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mathbench"
-version = "0.3.2"
+version = "0.4.0"
 authors = ["Cameron Hart <cameron.hart@gmail.com>"]
 edition = "2018"
 
@@ -16,9 +16,10 @@ nalgebra_f32x4 = ["nalgebra", "simba"]
 nalgebra_f32x8 = ["nalgebra", "simba"]
 nalgebra_wide = ["nalgebra_f32x4", "nalgebra_f32x8"]
 
+scalar = ["cgmath", "nalgebra", "ultraviolet", "euclid", "vek", "pathfinder_geometry", "static-math"]
 wide = ["ultraviolet_wide", "nalgebra_wide"]
 
-all = ["wide", "euclid", "vek", "pathfinder_geometry", "static-math"]
+all = ["scalar", "wide"]
 
 unstable = []
 
@@ -120,7 +121,7 @@ name = "vector3"
 harness = false
 
 [profile.bench]
-codegen-units = 1
+# codegen-units = 1
 # lto = true
 
 [workspace]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [features]
 # defaults can be disabled for benchmarks but are required for tests
-default = ["cgmath", "nalgebra","ultraviolet"]
+default = ["cgmath", "nalgebra", "ultraviolet"]
 
 ultraviolet_f32x4 = ["ultraviolet"]
 ultraviolet_f32x8 = ["ultraviolet"]

--- a/benches/eulerbench.rs
+++ b/benches/eulerbench.rs
@@ -77,7 +77,7 @@ fn bench_euler_3d_wide(c: &mut Criterion) {
     let mut group = c.benchmark_group("wide euler 3d");
     for size in [80000].iter() {
         group.throughput(Throughput::Elements(*size as u64));
-        bench_glam!(group, size, |b, size| {
+        bench_glam_f32x1!(group, size, |b, size| {
             use glam::Vec3A;
             bench_euler!(b, size, ty => Vec3A, zero => Vec3A::zero(), dt => Vec3A::splat(UPDATE_RATE))
         });
@@ -151,7 +151,7 @@ fn bench_euler_2d_wide(c: &mut Criterion) {
     let mut group = c.benchmark_group("wide euler 2d");
     for size in [80000].iter() {
         group.throughput(Throughput::Elements(*size as u64));
-        bench_glam!(group, size, |b, size| {
+        bench_glam_f32x1!(group, size, |b, size| {
             use glam::Vec2;
             bench_euler!(b, size, ty => Vec2, zero => Vec2::zero(), dt => Vec2::splat(UPDATE_RATE))
         });

--- a/benches/matrix2.rs
+++ b/benches/matrix2.rs
@@ -2,6 +2,7 @@
 #[macro_use]
 mod macros;
 use criterion::{criterion_group, criterion_main, Criterion};
+use macros::MIN_WIDE_BENCH_SIZE;
 
 // returns self to check overhead of benchmark
 fn bench_matrix2_ret_self(c: &mut Criterion) {
@@ -40,27 +41,27 @@ fn bench_matrix2_ret_self(c: &mut Criterion) {
 
 fn bench_matrix2_ret_self_wide(c: &mut Criterion) {
     use mathbench::BenchValue;
-    let size = &macros::MIN_WIDE_BENCH_SIZE;
+    let size = &MIN_WIDE_BENCH_SIZE;
     let mut group = c.benchmark_group("wide matrix2 return self");
     group.throughput(criterion::Throughput::Elements(*size));
-    bench_glam_f32x1!(group, |b| {
+    bench_glam_f32x1!(group, size, |b, size| {
         use glam::Mat2;
         bench_unop_wide!(b, size, width => 1, op => ret_self, ty => Mat2)
     });
-    bench_ultraviolet_f32x4!(group, |b| {
+    bench_ultraviolet_f32x4!(group, size, |b, size| {
         use ultraviolet::Mat2x4;
         bench_unop_wide!(b, size, width => 4, op => ret_self, ty => Mat2x4)
     });
-    bench_nalgebra_f32x4!(group, |b| {
+    bench_nalgebra_f32x4!(group, size, |b, size| {
         use nalgebra::Matrix2;
         use simba::simd::f32x4;
         bench_unop_wide!(b, size, width => 4, op => ret_self, ty => Matrix2<f32x4>)
     });
-    bench_ultraviolet_f32x8!(group, |b| {
+    bench_ultraviolet_f32x8!(group, size, |b, size| {
         use ultraviolet::Mat2x8;
         bench_unop_wide!(b, size, width => 8, op => ret_self, ty => Mat2x8)
     });
-    bench_nalgebra_f32x8!(group, |b| {
+    bench_nalgebra_f32x8!(group, size, |b, size| {
         use nalgebra::Matrix2;
         use simba::simd::f32x8;
         bench_unop_wide!(b, size, width => 8, op => ret_self, ty => Matrix2<f32x8>)
@@ -100,26 +101,26 @@ fn bench_matrix2_transpose(c: &mut Criterion) {
 
 fn bench_matrix2_transpose_wide(c: &mut Criterion) {
     let mut group = c.benchmark_group("wide matrix2 transpose");
-    let size = &macros::MIN_WIDE_BENCH_SIZE;
+    let size = &MIN_WIDE_BENCH_SIZE;
     group.throughput(criterion::Throughput::Elements(*size));
-    bench_glam_f32x1!(group, |b| {
+    bench_glam_f32x1!(group, size, |b, size| {
         use glam::Mat2;
         bench_unop_wide!(b, size, width => 1, op => transpose, ty => Mat2)
     });
-    bench_ultraviolet_f32x4!(group, |b| {
+    bench_ultraviolet_f32x4!(group, size, |b, size| {
         use ultraviolet::Mat2x4;
         bench_unop_wide!(b, size, width => 4, op => transposed, ty => Mat2x4)
     });
-    bench_nalgebra_f32x4!(group, |b| {
+    bench_nalgebra_f32x4!(group, size, |b, size| {
         use nalgebra::Matrix2;
         use simba::simd::f32x4;
         bench_unop_wide!(b, size, width => 4, op => transpose, ty => Matrix2<f32x4>)
     });
-    bench_ultraviolet_f32x8!(group, |b| {
+    bench_ultraviolet_f32x8!(group, size, |b, size| {
         use ultraviolet::Mat2x8;
         bench_unop_wide!(b, size, width => 8, op => transposed, ty => Mat2x8)
     });
-    bench_nalgebra_f32x8!(group, |b| {
+    bench_nalgebra_f32x8!(group, size, |b, size| {
         use nalgebra::Matrix2;
         use simba::simd::f32x8;
         bench_unop_wide!(b, size, width => 8, op => transpose, ty => Matrix2<f32x8>)
@@ -162,18 +163,18 @@ fn bench_matrix2_determinant(c: &mut Criterion) {
 }
 
 fn bench_matrix2_determinant_wide(c: &mut Criterion) {
-    let size = &macros::MIN_WIDE_BENCH_SIZE;
+    let size = &MIN_WIDE_BENCH_SIZE;
     let mut group = c.benchmark_group("wide matrix2 determinant");
     group.throughput(criterion::Throughput::Elements(*size));
-    bench_glam_f32x1!(group, |b| {
+    bench_glam_f32x1!(group, size, |b, size| {
         use glam::Mat2;
         bench_unop_wide!(b, size, width => 1, op => determinant, ty => Mat2)
     });
-    bench_ultraviolet_f32x4!(group, |b| {
+    bench_ultraviolet_f32x4!(group, size, |b, size| {
         use ultraviolet::Mat2x4;
         bench_unop_wide!(b, size, width => 4, op => determinant, ty => Mat2x4)
     });
-    bench_ultraviolet_f32x8!(group, |b| {
+    bench_ultraviolet_f32x8!(group, size, |b, size| {
         use ultraviolet::Mat2x8;
         bench_unop_wide!(b, size, width => 8, op => determinant, ty => Mat2x8)
     });
@@ -211,18 +212,18 @@ fn bench_matrix2_inverse(c: &mut Criterion) {
 }
 
 fn bench_matrix2_inverse_wide(c: &mut Criterion) {
-    let size = &macros::MIN_WIDE_BENCH_SIZE;
+    let size = &MIN_WIDE_BENCH_SIZE;
     let mut group = c.benchmark_group("wide matrix2 inverse");
     group.throughput(criterion::Throughput::Elements(*size));
-    bench_glam_f32x1!(group, |b| {
+    bench_glam_f32x1!(group, size, |b, size| {
         use glam::Mat2;
         bench_unop_wide!(b, size, width => 1, op => inverse, ty => Mat2)
     });
-    bench_ultraviolet_f32x4!(group, |b| {
+    bench_ultraviolet_f32x4!(group, size, |b, size| {
         use ultraviolet::Mat2x4;
         bench_unop_wide!(b, size, width => 4, op => inversed, ty => Mat2x4)
     });
-    bench_ultraviolet_f32x8!(group, |b| {
+    bench_ultraviolet_f32x8!(group, size, |b, size| {
         use ultraviolet::Mat2x8;
         bench_unop_wide!(b, size, width => 8, op => inversed, ty => Mat2x8)
     });
@@ -268,24 +269,24 @@ fn bench_matrix2_mul_matrix2_wide(c: &mut Criterion) {
     let mut group = c.benchmark_group("wide matrix2 mul matrix2");
     for size in [16, 256].iter() {
         group.throughput(criterion::Throughput::Elements(*size as u64));
-        bench_glam_f32x1!(group, |b| {
+        bench_glam_f32x1!(group, size, |b, size| {
             use glam::Mat2;
             bench_binop_wide!(b, size, width => 1, op => mul, ty1 => Mat2, ty2 => Mat2)
         });
-        bench_ultraviolet_f32x4!(group, |b| {
+        bench_ultraviolet_f32x4!(group, size, |b, size| {
             use ultraviolet::Mat2x4;
             bench_binop_wide!(b, size, width => 4, op => mul, ty1 => Mat2x4, ty2 => Mat2x4)
         });
-        bench_nalgebra_f32x4!(group, |b| {
+        bench_nalgebra_f32x4!(group, size, |b, size| {
             use nalgebra::Matrix2;
             use simba::simd::f32x4;
             bench_binop_wide!(b, size, width => 4, op => mul, ty1 => Matrix2<f32x4>, ty2 => Matrix2<f32x4>)
         });
-        bench_ultraviolet_f32x8!(group, |b| {
+        bench_ultraviolet_f32x8!(group, size, |b, size| {
             use ultraviolet::Mat2x8;
             bench_binop_wide!(b, size, width => 8, op => mul, ty1 => Mat2x8, ty2 => Mat2x8)
         });
-        bench_nalgebra_f32x8!(group, |b| {
+        bench_nalgebra_f32x8!(group, size, |b, size| {
             use nalgebra::Matrix2;
             use simba::simd::f32x8;
             bench_binop_wide!(b, size, width => 8, op => mul, ty1 => Matrix2<f32x8>, ty2 => Matrix2<f32x8>)
@@ -337,24 +338,24 @@ fn bench_matrix2_mul_vector2_wide(c: &mut Criterion) {
     let mut group = c.benchmark_group("wide matrix2 mul vector2");
     for size in [16, 256].iter() {
         group.throughput(criterion::Throughput::Elements(*size as u64));
-        bench_glam_f32x1!(group, |b| {
+        bench_glam_f32x1!(group, size, |b, size| {
             use glam::{Mat2, Vec2};
             bench_binop_wide!(b, size, width => 1, op => mul, ty1 => Mat2, ty2 => Vec2)
         });
-        bench_ultraviolet_f32x4!(group, |b| {
+        bench_ultraviolet_f32x4!(group, size, |b, size| {
             use ultraviolet::{Mat2x4, Vec2x4};
             bench_binop_wide!(b, size, width => 4, op => mul, ty1 => Mat2x4, ty2 => Vec2x4)
         });
-        bench_nalgebra_f32x4!(group, |b| {
+        bench_nalgebra_f32x4!(group, size, |b, size| {
             use nalgebra::{Matrix2, Vector2};
             use simba::simd::f32x4;
             bench_binop_wide!(b, size, width => 4, op => mul, ty1 => Matrix2<f32x4>, ty2 => Vector2<f32x4>)
         });
-        bench_ultraviolet_f32x8!(group, |b| {
+        bench_ultraviolet_f32x8!(group, size, |b, size| {
             use ultraviolet::{Mat2x8, Vec2x8};
             bench_binop_wide!(b, size, width => 8, op => mul, ty1 => Mat2x8, ty2 => Vec2x8)
         });
-        bench_nalgebra_f32x8!(group, |b| {
+        bench_nalgebra_f32x8!(group, size, |b, size| {
             use nalgebra::{Matrix2, Vector2};
             use simba::simd::f32x8;
             bench_binop_wide!(b, size, width => 8, op => mul, ty1 => Matrix2<f32x8>, ty2 => Vector2<f32x8>)

--- a/benches/matrix2.rs
+++ b/benches/matrix2.rs
@@ -40,28 +40,30 @@ fn bench_matrix2_ret_self(c: &mut Criterion) {
 
 fn bench_matrix2_ret_self_wide(c: &mut Criterion) {
     use mathbench::BenchValue;
+    let size = &macros::MIN_WIDE_BENCH_SIZE;
     let mut group = c.benchmark_group("wide matrix2 return self");
-    bench_glam!(group, |b| {
+    group.throughput(criterion::Throughput::Elements(*size));
+    bench_glam_f32x1!(group, |b| {
         use glam::Mat2;
-        bench_unop_wide!(b, op => ret_self, ty => Mat2)
+        bench_unop_wide!(b, size, width => 1, op => ret_self, ty => Mat2)
     });
     bench_ultraviolet_f32x4!(group, |b| {
         use ultraviolet::Mat2x4;
-        bench_unop_wide!(b, width => 4, op => ret_self, ty => Mat2x4)
+        bench_unop_wide!(b, size, width => 4, op => ret_self, ty => Mat2x4)
     });
     bench_nalgebra_f32x4!(group, |b| {
         use nalgebra::Matrix2;
         use simba::simd::f32x4;
-        bench_unop_wide!(b, width => 4, op => ret_self, ty => Matrix2<f32x4>)
+        bench_unop_wide!(b, size, width => 4, op => ret_self, ty => Matrix2<f32x4>)
     });
     bench_ultraviolet_f32x8!(group, |b| {
         use ultraviolet::Mat2x8;
-        bench_unop_wide!(b, width => 8, op => ret_self, ty => Mat2x8)
+        bench_unop_wide!(b, size, width => 8, op => ret_self, ty => Mat2x8)
     });
     bench_nalgebra_f32x8!(group, |b| {
         use nalgebra::Matrix2;
         use simba::simd::f32x8;
-        bench_unop_wide!(b, width => 8, op => ret_self, ty => Matrix2<f32x8>)
+        bench_unop_wide!(b, size, width => 8, op => ret_self, ty => Matrix2<f32x8>)
     });
     group.finish();
 }
@@ -98,27 +100,29 @@ fn bench_matrix2_transpose(c: &mut Criterion) {
 
 fn bench_matrix2_transpose_wide(c: &mut Criterion) {
     let mut group = c.benchmark_group("wide matrix2 transpose");
-    bench_glam!(group, |b| {
+    let size = &macros::MIN_WIDE_BENCH_SIZE;
+    group.throughput(criterion::Throughput::Elements(*size));
+    bench_glam_f32x1!(group, |b| {
         use glam::Mat2;
-        bench_unop_wide!(b, op => transpose, ty => Mat2)
+        bench_unop_wide!(b, size, width => 1, op => transpose, ty => Mat2)
     });
     bench_ultraviolet_f32x4!(group, |b| {
         use ultraviolet::Mat2x4;
-        bench_unop_wide!(b, width => 4, op => transposed, ty => Mat2x4)
+        bench_unop_wide!(b, size, width => 4, op => transposed, ty => Mat2x4)
     });
     bench_nalgebra_f32x4!(group, |b| {
         use nalgebra::Matrix2;
         use simba::simd::f32x4;
-        bench_unop_wide!(b, width => 4, op => transpose, ty => Matrix2<f32x4>)
+        bench_unop_wide!(b, size, width => 4, op => transpose, ty => Matrix2<f32x4>)
     });
     bench_ultraviolet_f32x8!(group, |b| {
         use ultraviolet::Mat2x8;
-        bench_unop_wide!(b, width => 8, op => transposed, ty => Mat2x8)
+        bench_unop_wide!(b, size, width => 8, op => transposed, ty => Mat2x8)
     });
     bench_nalgebra_f32x8!(group, |b| {
         use nalgebra::Matrix2;
         use simba::simd::f32x8;
-        bench_unop_wide!(b, width => 8, op => transpose, ty => Matrix2<f32x8>)
+        bench_unop_wide!(b, size, width => 8, op => transpose, ty => Matrix2<f32x8>)
     });
     group.finish();
 }
@@ -158,18 +162,20 @@ fn bench_matrix2_determinant(c: &mut Criterion) {
 }
 
 fn bench_matrix2_determinant_wide(c: &mut Criterion) {
+    let size = &macros::MIN_WIDE_BENCH_SIZE;
     let mut group = c.benchmark_group("wide matrix2 determinant");
-    bench_glam!(group, |b| {
+    group.throughput(criterion::Throughput::Elements(*size));
+    bench_glam_f32x1!(group, |b| {
         use glam::Mat2;
-        bench_unop_wide!(b, op => determinant, ty => Mat2)
+        bench_unop_wide!(b, size, width => 1, op => determinant, ty => Mat2)
     });
     bench_ultraviolet_f32x4!(group, |b| {
         use ultraviolet::Mat2x4;
-        bench_unop_wide!(b, width => 4, op => determinant, ty => Mat2x4)
+        bench_unop_wide!(b, size, width => 4, op => determinant, ty => Mat2x4)
     });
     bench_ultraviolet_f32x8!(group, |b| {
         use ultraviolet::Mat2x8;
-        bench_unop_wide!(b, width => 8, op => determinant, ty => Mat2x8)
+        bench_unop_wide!(b, size, width => 8, op => determinant, ty => Mat2x8)
     });
     group.finish();
 }
@@ -205,18 +211,20 @@ fn bench_matrix2_inverse(c: &mut Criterion) {
 }
 
 fn bench_matrix2_inverse_wide(c: &mut Criterion) {
+    let size = &macros::MIN_WIDE_BENCH_SIZE;
     let mut group = c.benchmark_group("wide matrix2 inverse");
-    bench_glam!(group, |b| {
+    group.throughput(criterion::Throughput::Elements(*size));
+    bench_glam_f32x1!(group, |b| {
         use glam::Mat2;
-        bench_unop_wide!(b, op => inverse, ty => Mat2)
+        bench_unop_wide!(b, size, width => 1, op => inverse, ty => Mat2)
     });
     bench_ultraviolet_f32x4!(group, |b| {
         use ultraviolet::Mat2x4;
-        bench_unop_wide!(b, width => 4, op => inversed, ty => Mat2x4)
+        bench_unop_wide!(b, size, width => 4, op => inversed, ty => Mat2x4)
     });
     bench_ultraviolet_f32x8!(group, |b| {
         use ultraviolet::Mat2x8;
-        bench_unop_wide!(b, width => 8, op => inversed, ty => Mat2x8)
+        bench_unop_wide!(b, size, width => 8, op => inversed, ty => Mat2x8)
     });
     group.finish();
 }
@@ -260,7 +268,7 @@ fn bench_matrix2_mul_matrix2_wide(c: &mut Criterion) {
     let mut group = c.benchmark_group("wide matrix2 mul matrix2");
     for size in [16, 256].iter() {
         group.throughput(criterion::Throughput::Elements(*size as u64));
-        bench_glam!(group, |b| {
+        bench_glam_f32x1!(group, |b| {
             use glam::Mat2;
             bench_binop_wide!(b, size, width => 1, op => mul, ty1 => Mat2, ty2 => Mat2)
         });
@@ -329,7 +337,7 @@ fn bench_matrix2_mul_vector2_wide(c: &mut Criterion) {
     let mut group = c.benchmark_group("wide matrix2 mul vector2");
     for size in [16, 256].iter() {
         group.throughput(criterion::Throughput::Elements(*size as u64));
-        bench_glam!(group, |b| {
+        bench_glam_f32x1!(group, |b| {
             use glam::{Mat2, Vec2};
             bench_binop_wide!(b, size, width => 1, op => mul, ty1 => Mat2, ty2 => Vec2)
         });

--- a/benches/matrix3.rs
+++ b/benches/matrix3.rs
@@ -2,6 +2,7 @@
 #[macro_use]
 mod macros;
 use criterion::{criterion_group, criterion_main, Criterion};
+use macros::MIN_WIDE_BENCH_SIZE;
 
 fn bench_matrix3_ret_self(c: &mut Criterion) {
     use mathbench::BenchValue;
@@ -35,27 +36,27 @@ fn bench_matrix3_ret_self(c: &mut Criterion) {
 
 fn bench_matrix3_ret_self_wide(c: &mut Criterion) {
     use mathbench::BenchValue;
-    let size = &macros::MIN_WIDE_BENCH_SIZE;
+    let size = &MIN_WIDE_BENCH_SIZE;
     let mut group = c.benchmark_group("wide matrix3 return self");
     group.throughput(criterion::Throughput::Elements(*size));
-    bench_glam_f32x1!(group, |b| {
+    bench_glam_f32x1!(group, size, |b, size| {
         use glam::Mat3;
         bench_unop_wide!(b, size, width => 1, op => ret_self, ty => Mat3)
     });
-    bench_ultraviolet_f32x4!(group, |b| {
+    bench_ultraviolet_f32x4!(group, size, |b, size| {
         use ultraviolet::Mat3x4;
         bench_unop_wide!(b, size, width => 4, op => ret_self, ty => Mat3x4)
     });
-    bench_nalgebra_f32x4!(group, |b| {
+    bench_nalgebra_f32x4!(group, size, |b, size| {
         use nalgebra::Matrix3;
         use simba::simd::f32x4;
         bench_unop_wide!(b, size, width => 4, op => ret_self, ty => Matrix3<f32x4>)
     });
-    bench_ultraviolet_f32x8!(group, |b| {
+    bench_ultraviolet_f32x8!(group, size, |b, size| {
         use ultraviolet::Mat3x8;
         bench_unop_wide!(b, size, width => 8, op => ret_self, ty => Mat3x8)
     });
-    bench_nalgebra_f32x8!(group, |b| {
+    bench_nalgebra_f32x8!(group, size, |b, size| {
         use nalgebra::Matrix3;
         use simba::simd::f32x8;
         bench_unop_wide!(b, size, width => 8, op => ret_self, ty => Matrix3<f32x8>)
@@ -94,27 +95,27 @@ fn bench_matrix3_transpose(c: &mut Criterion) {
 }
 
 fn bench_matrix3_transpose_wide(c: &mut Criterion) {
-    let size = &macros::MIN_WIDE_BENCH_SIZE;
+    let size = &MIN_WIDE_BENCH_SIZE;
     let mut group = c.benchmark_group("wide matrix3 transpose");
     group.throughput(criterion::Throughput::Elements(*size));
-    bench_glam_f32x1!(group, |b| {
+    bench_glam_f32x1!(group, size, |b, size| {
         use glam::Mat3;
         bench_unop_wide!(b, size, width => 1, op => transpose, ty => Mat3)
     });
-    bench_ultraviolet_f32x4!(group, |b| {
+    bench_ultraviolet_f32x4!(group, size, |b, size| {
         use ultraviolet::Mat3x4;
         bench_unop_wide!(b, size, width => 4, op => transposed, ty => Mat3x4)
     });
-    bench_nalgebra_f32x4!(group, |b| {
+    bench_nalgebra_f32x4!(group, size, |b, size| {
         use nalgebra::Matrix3;
         use simba::simd::f32x4;
         bench_unop_wide!(b, size, width => 4, op => transpose, ty => Matrix3<f32x4>)
     });
-    bench_ultraviolet_f32x8!(group, |b| {
+    bench_ultraviolet_f32x8!(group, size, |b, size| {
         use ultraviolet::Mat3x8;
         bench_unop_wide!(b, size, width => 8, op => transposed, ty => Mat3x8)
     });
-    bench_nalgebra_f32x8!(group, |b| {
+    bench_nalgebra_f32x8!(group, size, |b, size| {
         use nalgebra::Matrix3;
         use simba::simd::f32x8;
         bench_unop_wide!(b, size, width => 8, op => transpose, ty => Matrix3<f32x8>)
@@ -153,18 +154,18 @@ fn bench_matrix3_determinant(c: &mut Criterion) {
 }
 
 fn bench_matrix3_determinant_wide(c: &mut Criterion) {
-    let size = &macros::MIN_WIDE_BENCH_SIZE;
+    let size = &MIN_WIDE_BENCH_SIZE;
     let mut group = c.benchmark_group("wide matrix3 determinant");
     group.throughput(criterion::Throughput::Elements(*size));
-    bench_glam_f32x1!(group, |b| {
+    bench_glam_f32x1!(group, size, |b, size| {
         use glam::Mat3;
         bench_unop_wide!(b, size, width => 1, op => determinant, ty => Mat3)
     });
-    bench_ultraviolet_f32x4!(group, |b| {
+    bench_ultraviolet_f32x4!(group, size, |b, size| {
         use ultraviolet::Mat3x4;
         bench_unop_wide!(b, size, width => 4, op => determinant, ty => Mat3x4)
     });
-    bench_ultraviolet_f32x8!(group, |b| {
+    bench_ultraviolet_f32x8!(group, size, |b, size| {
         use ultraviolet::Mat3x8;
         bench_unop_wide!(b, size, width => 8, op => determinant, ty => Mat3x8)
     });
@@ -198,18 +199,18 @@ fn bench_matrix3_inverse(c: &mut Criterion) {
 }
 
 fn bench_matrix3_inverse_wide(c: &mut Criterion) {
-    let size = &macros::MIN_WIDE_BENCH_SIZE;
+    let size = &MIN_WIDE_BENCH_SIZE;
     let mut group = c.benchmark_group("wide matrix3 inverse");
     group.throughput(criterion::Throughput::Elements(*size));
-    bench_glam_f32x1!(group, |b| {
+    bench_glam_f32x1!(group, size, |b, size| {
         use glam::Mat3;
         bench_unop_wide!(b, size, width => 1, op => inverse, ty => Mat3)
     });
-    bench_ultraviolet_f32x4!(group, |b| {
+    bench_ultraviolet_f32x4!(group, size, |b, size| {
         use ultraviolet::Mat3x4;
         bench_unop_wide!(b, size, width => 4, op => inversed, ty => Mat3x4)
     });
-    bench_ultraviolet_f32x8!(group, |b| {
+    bench_ultraviolet_f32x8!(group, size, |b, size| {
         use ultraviolet::Mat3x8;
         bench_unop_wide!(b, size, width => 8, op => inversed, ty => Mat3x8)
     });
@@ -251,24 +252,24 @@ fn bench_matrix3_mul_matrix3_wide(c: &mut Criterion) {
     let mut group = c.benchmark_group("wide matrix3 mul matrix3");
     for size in [16, 256].iter() {
         group.throughput(criterion::Throughput::Elements(*size as u64));
-        bench_glam_f32x1!(group, |b| {
+        bench_glam_f32x1!(group, size, |b, size| {
             use glam::Mat3;
             bench_binop_wide!(b, size, width => 1, op => mul, ty1 => Mat3, ty2 => Mat3)
         });
-        bench_ultraviolet_f32x4!(group, |b| {
+        bench_ultraviolet_f32x4!(group, size, |b, size| {
             use ultraviolet::Mat3x4;
             bench_binop_wide!(b, size, width => 4, op => mul, ty1 => Mat3x4, ty2 => Mat3x4)
         });
-        bench_nalgebra_f32x4!(group, |b| {
+        bench_nalgebra_f32x4!(group, size, |b, size| {
             use nalgebra::Matrix3;
             use simba::simd::f32x4;
             bench_binop_wide!(b, size, width => 4, op => mul, ty1 => Matrix3<f32x4>, ty2 => Matrix3<f32x4>)
         });
-        bench_ultraviolet_f32x8!(group, |b| {
+        bench_ultraviolet_f32x8!(group, size, |b, size| {
             use ultraviolet::Mat3x8;
             bench_binop_wide!(b, size, width => 8, op => mul, ty1 => Mat3x8, ty2 => Mat3x8)
         });
-        bench_nalgebra_f32x8!(group, |b| {
+        bench_nalgebra_f32x8!(group, size, |b, size| {
             use nalgebra::Matrix3;
             use simba::simd::f32x8;
             bench_binop_wide!(b, size, width => 8, op => mul, ty1 => Matrix3<f32x8>, ty2 => Matrix3<f32x8>)
@@ -316,24 +317,24 @@ fn bench_matrix3_mul_vector3_wide(c: &mut Criterion) {
     let mut group = c.benchmark_group("wide matrix3 mul vector3");
     for size in [16, 256].iter() {
         group.throughput(criterion::Throughput::Elements(*size as u64));
-        bench_glam_f32x1!(group, |b| {
+        bench_glam_f32x1!(group, size, |b, size| {
             use glam::{Mat3, Vec3};
             bench_binop_wide!(b, size, width => 1, op => mul, ty1 => Mat3, ty2 => Vec3)
         });
-        bench_ultraviolet_f32x4!(group, |b| {
+        bench_ultraviolet_f32x4!(group, size, |b, size| {
             use ultraviolet::{Mat3x4, Vec3x4};
             bench_binop_wide!(b, size, width => 4, op => mul, ty1 => Mat3x4, ty2 => Vec3x4)
         });
-        bench_nalgebra_f32x4!(group, |b| {
+        bench_nalgebra_f32x4!(group, size, |b, size| {
             use nalgebra::{Matrix3, Vector3};
             use simba::simd::f32x4;
             bench_binop_wide!(b, size, width => 4, op => mul, ty1 => Matrix3<f32x4>, ty2 => Vector3<f32x4>)
         });
-        bench_ultraviolet_f32x8!(group, |b| {
+        bench_ultraviolet_f32x8!(group, size, |b, size| {
             use ultraviolet::{Mat3x8, Vec3x8};
             bench_binop_wide!(b, size, width => 8, op => mul, ty1 => Mat3x8, ty2 => Vec3x8)
         });
-        bench_nalgebra_f32x8!(group, |b| {
+        bench_nalgebra_f32x8!(group, size, |b, size| {
             use nalgebra::{Matrix3, Vector3};
             use simba::simd::f32x8;
             bench_binop_wide!(b, size, width => 8, op => mul, ty1 => Matrix3<f32x8>, ty2 => Vector3<f32x8>)

--- a/benches/matrix3.rs
+++ b/benches/matrix3.rs
@@ -35,28 +35,30 @@ fn bench_matrix3_ret_self(c: &mut Criterion) {
 
 fn bench_matrix3_ret_self_wide(c: &mut Criterion) {
     use mathbench::BenchValue;
+    let size = &macros::MIN_WIDE_BENCH_SIZE;
     let mut group = c.benchmark_group("wide matrix3 return self");
-    bench_glam!(group, |b| {
+    group.throughput(criterion::Throughput::Elements(*size));
+    bench_glam_f32x1!(group, |b| {
         use glam::Mat3;
-        bench_unop_wide!(b, op => ret_self, ty => Mat3)
+        bench_unop_wide!(b, size, width => 1, op => ret_self, ty => Mat3)
     });
     bench_ultraviolet_f32x4!(group, |b| {
         use ultraviolet::Mat3x4;
-        bench_unop_wide!(b, width => 4, op => ret_self, ty => Mat3x4)
+        bench_unop_wide!(b, size, width => 4, op => ret_self, ty => Mat3x4)
     });
     bench_nalgebra_f32x4!(group, |b| {
         use nalgebra::Matrix3;
         use simba::simd::f32x4;
-        bench_unop_wide!(b, width => 4, op => ret_self, ty => Matrix3<f32x4>)
+        bench_unop_wide!(b, size, width => 4, op => ret_self, ty => Matrix3<f32x4>)
     });
     bench_ultraviolet_f32x8!(group, |b| {
         use ultraviolet::Mat3x8;
-        bench_unop_wide!(b, width => 8, op => ret_self, ty => Mat3x8)
+        bench_unop_wide!(b, size, width => 8, op => ret_self, ty => Mat3x8)
     });
     bench_nalgebra_f32x8!(group, |b| {
         use nalgebra::Matrix3;
         use simba::simd::f32x8;
-        bench_unop_wide!(b, width => 8, op => ret_self, ty => Matrix3<f32x8>)
+        bench_unop_wide!(b, size, width => 8, op => ret_self, ty => Matrix3<f32x8>)
     });
     group.finish();
 }
@@ -92,28 +94,30 @@ fn bench_matrix3_transpose(c: &mut Criterion) {
 }
 
 fn bench_matrix3_transpose_wide(c: &mut Criterion) {
+    let size = &macros::MIN_WIDE_BENCH_SIZE;
     let mut group = c.benchmark_group("wide matrix3 transpose");
-    bench_glam!(group, |b| {
+    group.throughput(criterion::Throughput::Elements(*size));
+    bench_glam_f32x1!(group, |b| {
         use glam::Mat3;
-        bench_unop_wide!(b, op => transpose, ty => Mat3)
+        bench_unop_wide!(b, size, width => 1, op => transpose, ty => Mat3)
     });
     bench_ultraviolet_f32x4!(group, |b| {
         use ultraviolet::Mat3x4;
-        bench_unop_wide!(b, width => 4, op => transposed, ty => Mat3x4)
+        bench_unop_wide!(b, size, width => 4, op => transposed, ty => Mat3x4)
     });
     bench_nalgebra_f32x4!(group, |b| {
         use nalgebra::Matrix3;
         use simba::simd::f32x4;
-        bench_unop_wide!(b, width => 4, op => transpose, ty => Matrix3<f32x4>)
+        bench_unop_wide!(b, size, width => 4, op => transpose, ty => Matrix3<f32x4>)
     });
     bench_ultraviolet_f32x8!(group, |b| {
         use ultraviolet::Mat3x8;
-        bench_unop_wide!(b, width => 8, op => transposed, ty => Mat3x8)
+        bench_unop_wide!(b, size, width => 8, op => transposed, ty => Mat3x8)
     });
     bench_nalgebra_f32x8!(group, |b| {
         use nalgebra::Matrix3;
         use simba::simd::f32x8;
-        bench_unop_wide!(b, width => 8, op => transpose, ty => Matrix3<f32x8>)
+        bench_unop_wide!(b, size, width => 8, op => transpose, ty => Matrix3<f32x8>)
     });
     group.finish();
 }
@@ -149,18 +153,20 @@ fn bench_matrix3_determinant(c: &mut Criterion) {
 }
 
 fn bench_matrix3_determinant_wide(c: &mut Criterion) {
+    let size = &macros::MIN_WIDE_BENCH_SIZE;
     let mut group = c.benchmark_group("wide matrix3 determinant");
-    bench_glam!(group, |b| {
+    group.throughput(criterion::Throughput::Elements(*size));
+    bench_glam_f32x1!(group, |b| {
         use glam::Mat3;
-        bench_unop_wide!(b, op => determinant, ty => Mat3)
+        bench_unop_wide!(b, size, width => 1, op => determinant, ty => Mat3)
     });
     bench_ultraviolet_f32x4!(group, |b| {
         use ultraviolet::Mat3x4;
-        bench_unop_wide!(b, width => 4, op => determinant, ty => Mat3x4)
+        bench_unop_wide!(b, size, width => 4, op => determinant, ty => Mat3x4)
     });
     bench_ultraviolet_f32x8!(group, |b| {
         use ultraviolet::Mat3x8;
-        bench_unop_wide!(b, width => 8, op => determinant, ty => Mat3x8)
+        bench_unop_wide!(b, size, width => 8, op => determinant, ty => Mat3x8)
     });
     group.finish();
 }
@@ -192,10 +198,12 @@ fn bench_matrix3_inverse(c: &mut Criterion) {
 }
 
 fn bench_matrix3_inverse_wide(c: &mut Criterion) {
+    let size = &macros::MIN_WIDE_BENCH_SIZE;
     let mut group = c.benchmark_group("wide matrix3 inverse");
-    bench_glam!(group, |b| {
+    group.throughput(criterion::Throughput::Elements(*size));
+    bench_glam_f32x1!(group, |b| {
         use glam::Mat3;
-        bench_unop_wide!(b, op => inverse, ty => Mat3)
+        bench_unop_wide!(b, size, width => 1, op => inverse, ty => Mat3)
     });
     bench_ultraviolet_f32x4!(group, |b| {
         use ultraviolet::Mat3x4;
@@ -243,7 +251,7 @@ fn bench_matrix3_mul_matrix3_wide(c: &mut Criterion) {
     let mut group = c.benchmark_group("wide matrix3 mul matrix3");
     for size in [16, 256].iter() {
         group.throughput(criterion::Throughput::Elements(*size as u64));
-        bench_glam!(group, |b| {
+        bench_glam_f32x1!(group, |b| {
             use glam::Mat3;
             bench_binop_wide!(b, size, width => 1, op => mul, ty1 => Mat3, ty2 => Mat3)
         });
@@ -308,7 +316,7 @@ fn bench_matrix3_mul_vector3_wide(c: &mut Criterion) {
     let mut group = c.benchmark_group("wide matrix3 mul vector3");
     for size in [16, 256].iter() {
         group.throughput(criterion::Throughput::Elements(*size as u64));
-        bench_glam!(group, |b| {
+        bench_glam_f32x1!(group, |b| {
             use glam::{Mat3, Vec3};
             bench_binop_wide!(b, size, width => 1, op => mul, ty1 => Mat3, ty2 => Vec3)
         });

--- a/benches/matrix3.rs
+++ b/benches/matrix3.rs
@@ -207,11 +207,11 @@ fn bench_matrix3_inverse_wide(c: &mut Criterion) {
     });
     bench_ultraviolet_f32x4!(group, |b| {
         use ultraviolet::Mat3x4;
-        bench_unop_wide!(b, width => 4, op => inversed, ty => Mat3x4)
+        bench_unop_wide!(b, size, width => 4, op => inversed, ty => Mat3x4)
     });
     bench_ultraviolet_f32x8!(group, |b| {
         use ultraviolet::Mat3x8;
-        bench_unop_wide!(b, width => 8, op => inversed, ty => Mat3x8)
+        bench_unop_wide!(b, size, width => 8, op => inversed, ty => Mat3x8)
     });
     group.finish();
 }

--- a/benches/matrix4.rs
+++ b/benches/matrix4.rs
@@ -211,7 +211,7 @@ fn bench_matrix4_inverse(c: &mut Criterion) {
 }
 
 fn bench_matrix4_inverse_wide(c: &mut Criterion) {
-    let mut group = c.benchmark_group("scalar wide matrix4 inverse");
+    let mut group = c.benchmark_group("wide matrix4 inverse");
     let size = &macros::MIN_WIDE_BENCH_SIZE;
     group.throughput(criterion::Throughput::Elements(*size));
     bench_glam_f32x1!(group, |b| {

--- a/benches/matrix4.rs
+++ b/benches/matrix4.rs
@@ -36,28 +36,30 @@ fn bench_matrix4_ret_self(c: &mut Criterion) {
 
 fn bench_matrix4_ret_self_wide(c: &mut Criterion) {
     use mathbench::BenchValue;
+    let size = &macros::MIN_WIDE_BENCH_SIZE;
     let mut group = c.benchmark_group("wide matrix4 return self");
-    bench_glam!(group, |b| {
+    group.throughput(criterion::Throughput::Elements(*size));
+    bench_glam_f32x1!(group, |b| {
         use glam::Mat4;
-        bench_unop_wide!(b, op => ret_self, ty => Mat4)
+        bench_unop_wide!(b, size, width => 1, op => ret_self, ty => Mat4)
     });
     bench_ultraviolet_f32x4!(group, |b| {
         use ultraviolet::Mat4x4;
-        bench_unop_wide!(b, width => 4, op => ret_self, ty => Mat4x4)
+        bench_unop_wide!(b, size, width => 4, op => ret_self, ty => Mat4x4)
     });
     bench_nalgebra_f32x4!(group, |b| {
         use nalgebra::Matrix4;
         use simba::simd::f32x4;
-        bench_unop_wide!(b, width => 4, op => ret_self, ty => Matrix4<f32x4>)
+        bench_unop_wide!(b, size, width => 4, op => ret_self, ty => Matrix4<f32x4>)
     });
     bench_ultraviolet_f32x8!(group, |b| {
         use ultraviolet::Mat4x8;
-        bench_unop_wide!(b, width => 8, op => ret_self, ty => Mat4x8)
+        bench_unop_wide!(b, size, width => 8, op => ret_self, ty => Mat4x8)
     });
     bench_nalgebra_f32x8!(group, |b| {
         use nalgebra::Matrix4;
         use simba::simd::f32x8;
-        bench_unop_wide!(b, width => 8, op => ret_self, ty => Matrix4<f32x8>)
+        bench_unop_wide!(b, size, width => 8, op => ret_self, ty => Matrix4<f32x8>)
     });
     group.finish();
 }
@@ -93,28 +95,30 @@ fn bench_matrix4_transpose(c: &mut Criterion) {
 }
 
 fn bench_matrix4_transpose_wide(c: &mut Criterion) {
+    let size = &macros::MIN_WIDE_BENCH_SIZE;
     let mut group = c.benchmark_group("wide matrix4 transpose");
-    bench_glam!(group, |b| {
+    group.throughput(criterion::Throughput::Elements(*size));
+    bench_glam_f32x1!(group, |b| {
         use glam::Mat4;
-        bench_unop_wide!(b, op => transpose, ty => Mat4)
+        bench_unop_wide!(b, size, width => 1, op => transpose, ty => Mat4)
     });
     bench_ultraviolet_f32x4!(group, |b| {
         use ultraviolet::Mat4x4;
-        bench_unop_wide!(b, width => 4, op => transposed, ty => Mat4x4)
+        bench_unop_wide!(b, size, width => 4, op => transposed, ty => Mat4x4)
     });
     bench_nalgebra_f32x4!(group, |b| {
         use nalgebra::Matrix4;
         use simba::simd::f32x4;
-        bench_unop_wide!(b, width => 4, op => transpose, ty => Matrix4<f32x4>)
+        bench_unop_wide!(b, size, width => 4, op => transpose, ty => Matrix4<f32x4>)
     });
     bench_ultraviolet_f32x8!(group, |b| {
         use ultraviolet::Mat4x8;
-        bench_unop_wide!(b, width => 8, op => transposed, ty => Mat4x8)
+        bench_unop_wide!(b, size, width => 8, op => transposed, ty => Mat4x8)
     });
     bench_nalgebra_f32x8!(group, |b| {
         use nalgebra::Matrix4;
         use simba::simd::f32x8;
-        bench_unop_wide!(b, width => 8, op => transpose, ty => Matrix4<f32x8>)
+        bench_unop_wide!(b, size, width => 8, op => transpose, ty => Matrix4<f32x8>)
     });
     group.finish();
 }
@@ -154,18 +158,20 @@ fn bench_matrix4_determinant(c: &mut Criterion) {
 }
 
 fn bench_matrix4_determinant_wide(c: &mut Criterion) {
+    let size = &macros::MIN_WIDE_BENCH_SIZE;
     let mut group = c.benchmark_group("wide matrix4 determinant");
-    bench_glam!(group, |b| {
+    group.throughput(criterion::Throughput::Elements(*size));
+    bench_glam_f32x1!(group, |b| {
         use glam::Mat4;
-        bench_unop_wide!(b, op => determinant, ty => Mat4)
+        bench_unop_wide!(b, size, width => 1, op => determinant, ty => Mat4)
     });
     bench_ultraviolet_f32x4!(group, |b| {
         use ultraviolet::Mat4x4;
-        bench_unop_wide!(b, width => 4, op => determinant, ty => Mat4x4)
+        bench_unop_wide!(b, size, width => 4, op => determinant, ty => Mat4x4)
     });
     bench_ultraviolet_f32x8!(group, |b| {
         use ultraviolet::Mat4x8;
-        bench_unop_wide!(b, width => 8, op => determinant, ty => Mat4x8)
+        bench_unop_wide!(b, size, width => 8, op => determinant, ty => Mat4x8)
     });
     group.finish();
 }
@@ -206,17 +212,19 @@ fn bench_matrix4_inverse(c: &mut Criterion) {
 
 fn bench_matrix4_inverse_wide(c: &mut Criterion) {
     let mut group = c.benchmark_group("scalar wide matrix4 inverse");
-    bench_glam!(group, |b| {
+    let size = &macros::MIN_WIDE_BENCH_SIZE;
+    group.throughput(criterion::Throughput::Elements(*size));
+    bench_glam_f32x1!(group, |b| {
         use glam::Mat4;
-        bench_unop_wide!(b, op => inverse, ty => Mat4)
+        bench_unop_wide!(b, size, width => 1, op => inverse, ty => Mat4)
     });
     bench_ultraviolet_f32x4!(group, |b| {
         use ultraviolet::Mat4x4;
-        bench_unop_wide!(b, width => 4, op => inversed, ty => Mat4x4)
+        bench_unop_wide!(b, size, width => 4, op => inversed, ty => Mat4x4)
     });
     bench_ultraviolet_f32x8!(group, |b| {
         use ultraviolet::Mat4x8;
-        bench_unop_wide!(b, width => 8, op => inversed, ty => Mat4x8)
+        bench_unop_wide!(b, size, width => 8, op => inversed, ty => Mat4x8)
     });
     group.finish();
 }
@@ -260,7 +268,7 @@ fn bench_matrix4_mul_matrix4_wide(c: &mut Criterion) {
     let mut group = c.benchmark_group("wide matrix4 mul matrix4");
     for size in [16, 256].iter() {
         group.throughput(criterion::Throughput::Elements(*size as u64));
-        bench_glam!(group, |b| {
+        bench_glam_f32x1!(group, |b| {
             use glam::Mat4;
             bench_binop_wide!(b, size, width => 1, op => mul, ty1 => Mat4, ty2 => Mat4)
         });
@@ -325,7 +333,7 @@ fn bench_matrix4_mul_vector4_wide(c: &mut Criterion) {
     let mut group = c.benchmark_group("wide matrix4 mul vector4");
     for size in [16, 256].iter() {
         group.throughput(criterion::Throughput::Elements(*size as u64));
-        bench_glam!(group, |b| {
+        bench_glam_f32x1!(group, |b| {
             use glam::{Mat4, Vec4};
             bench_binop_wide!(b, size, width => 1, op => mul, ty1 => Mat4, ty2 => Vec4)
         });

--- a/benches/matrix4.rs
+++ b/benches/matrix4.rs
@@ -2,6 +2,7 @@
 #[macro_use]
 mod macros;
 use criterion::{criterion_group, criterion_main, Criterion};
+use macros::MIN_WIDE_BENCH_SIZE;
 
 // returns self to check overhead of benchmark
 fn bench_matrix4_ret_self(c: &mut Criterion) {
@@ -36,27 +37,27 @@ fn bench_matrix4_ret_self(c: &mut Criterion) {
 
 fn bench_matrix4_ret_self_wide(c: &mut Criterion) {
     use mathbench::BenchValue;
-    let size = &macros::MIN_WIDE_BENCH_SIZE;
+    let size = &MIN_WIDE_BENCH_SIZE;
     let mut group = c.benchmark_group("wide matrix4 return self");
-    group.throughput(criterion::Throughput::Elements(*size));
-    bench_glam_f32x1!(group, |b| {
+    group.throughput(criterion::Throughput::Elements(*size as u64));
+    bench_glam_f32x1!(group, size, |b, size| {
         use glam::Mat4;
         bench_unop_wide!(b, size, width => 1, op => ret_self, ty => Mat4)
     });
-    bench_ultraviolet_f32x4!(group, |b| {
+    bench_ultraviolet_f32x4!(group, size, |b, size| {
         use ultraviolet::Mat4x4;
         bench_unop_wide!(b, size, width => 4, op => ret_self, ty => Mat4x4)
     });
-    bench_nalgebra_f32x4!(group, |b| {
+    bench_nalgebra_f32x4!(group, size, |b, size| {
         use nalgebra::Matrix4;
         use simba::simd::f32x4;
         bench_unop_wide!(b, size, width => 4, op => ret_self, ty => Matrix4<f32x4>)
     });
-    bench_ultraviolet_f32x8!(group, |b| {
+    bench_ultraviolet_f32x8!(group, size, |b, size| {
         use ultraviolet::Mat4x8;
         bench_unop_wide!(b, size, width => 8, op => ret_self, ty => Mat4x8)
     });
-    bench_nalgebra_f32x8!(group, |b| {
+    bench_nalgebra_f32x8!(group, size, |b, size| {
         use nalgebra::Matrix4;
         use simba::simd::f32x8;
         bench_unop_wide!(b, size, width => 8, op => ret_self, ty => Matrix4<f32x8>)
@@ -95,27 +96,27 @@ fn bench_matrix4_transpose(c: &mut Criterion) {
 }
 
 fn bench_matrix4_transpose_wide(c: &mut Criterion) {
-    let size = &macros::MIN_WIDE_BENCH_SIZE;
+    let size = &MIN_WIDE_BENCH_SIZE;
     let mut group = c.benchmark_group("wide matrix4 transpose");
     group.throughput(criterion::Throughput::Elements(*size));
-    bench_glam_f32x1!(group, |b| {
+    bench_glam_f32x1!(group, size, |b, size| {
         use glam::Mat4;
         bench_unop_wide!(b, size, width => 1, op => transpose, ty => Mat4)
     });
-    bench_ultraviolet_f32x4!(group, |b| {
+    bench_ultraviolet_f32x4!(group, size, |b, size| {
         use ultraviolet::Mat4x4;
         bench_unop_wide!(b, size, width => 4, op => transposed, ty => Mat4x4)
     });
-    bench_nalgebra_f32x4!(group, |b| {
+    bench_nalgebra_f32x4!(group, size, |b, size| {
         use nalgebra::Matrix4;
         use simba::simd::f32x4;
         bench_unop_wide!(b, size, width => 4, op => transpose, ty => Matrix4<f32x4>)
     });
-    bench_ultraviolet_f32x8!(group, |b| {
+    bench_ultraviolet_f32x8!(group, size, |b, size| {
         use ultraviolet::Mat4x8;
         bench_unop_wide!(b, size, width => 8, op => transposed, ty => Mat4x8)
     });
-    bench_nalgebra_f32x8!(group, |b| {
+    bench_nalgebra_f32x8!(group, size, |b, size| {
         use nalgebra::Matrix4;
         use simba::simd::f32x8;
         bench_unop_wide!(b, size, width => 8, op => transpose, ty => Matrix4<f32x8>)
@@ -158,18 +159,18 @@ fn bench_matrix4_determinant(c: &mut Criterion) {
 }
 
 fn bench_matrix4_determinant_wide(c: &mut Criterion) {
-    let size = &macros::MIN_WIDE_BENCH_SIZE;
+    let size = &MIN_WIDE_BENCH_SIZE;
     let mut group = c.benchmark_group("wide matrix4 determinant");
     group.throughput(criterion::Throughput::Elements(*size));
-    bench_glam_f32x1!(group, |b| {
+    bench_glam_f32x1!(group, size, |b, size| {
         use glam::Mat4;
         bench_unop_wide!(b, size, width => 1, op => determinant, ty => Mat4)
     });
-    bench_ultraviolet_f32x4!(group, |b| {
+    bench_ultraviolet_f32x4!(group, size, |b, size| {
         use ultraviolet::Mat4x4;
         bench_unop_wide!(b, size, width => 4, op => determinant, ty => Mat4x4)
     });
-    bench_ultraviolet_f32x8!(group, |b| {
+    bench_ultraviolet_f32x8!(group, size, |b, size| {
         use ultraviolet::Mat4x8;
         bench_unop_wide!(b, size, width => 8, op => determinant, ty => Mat4x8)
     });
@@ -212,17 +213,17 @@ fn bench_matrix4_inverse(c: &mut Criterion) {
 
 fn bench_matrix4_inverse_wide(c: &mut Criterion) {
     let mut group = c.benchmark_group("wide matrix4 inverse");
-    let size = &macros::MIN_WIDE_BENCH_SIZE;
+    let size = &MIN_WIDE_BENCH_SIZE;
     group.throughput(criterion::Throughput::Elements(*size));
-    bench_glam_f32x1!(group, |b| {
+    bench_glam_f32x1!(group, size, |b, size| {
         use glam::Mat4;
         bench_unop_wide!(b, size, width => 1, op => inverse, ty => Mat4)
     });
-    bench_ultraviolet_f32x4!(group, |b| {
+    bench_ultraviolet_f32x4!(group, size, |b, size| {
         use ultraviolet::Mat4x4;
         bench_unop_wide!(b, size, width => 4, op => inversed, ty => Mat4x4)
     });
-    bench_ultraviolet_f32x8!(group, |b| {
+    bench_ultraviolet_f32x8!(group, size, |b, size| {
         use ultraviolet::Mat4x8;
         bench_unop_wide!(b, size, width => 8, op => inversed, ty => Mat4x8)
     });
@@ -268,24 +269,24 @@ fn bench_matrix4_mul_matrix4_wide(c: &mut Criterion) {
     let mut group = c.benchmark_group("wide matrix4 mul matrix4");
     for size in [16, 256].iter() {
         group.throughput(criterion::Throughput::Elements(*size as u64));
-        bench_glam_f32x1!(group, |b| {
+        bench_glam_f32x1!(group, size, |b, size| {
             use glam::Mat4;
             bench_binop_wide!(b, size, width => 1, op => mul, ty1 => Mat4, ty2 => Mat4)
         });
-        bench_ultraviolet_f32x4!(group, |b| {
+        bench_ultraviolet_f32x4!(group, size, |b, size| {
             use ultraviolet::Mat4x4;
             bench_binop_wide!(b, size, width => 4, op => mul, ty1 => Mat4x4, ty2 => Mat4x4)
         });
-        bench_nalgebra_f32x4!(group, |b| {
+        bench_nalgebra_f32x4!(group, size, |b, size| {
             use nalgebra::Matrix4;
             use simba::simd::f32x4;
             bench_binop_wide!(b, size, width => 4, op => mul, ty1 => Matrix4<f32x4>, ty2 => Matrix4<f32x4>)
         });
-        bench_ultraviolet_f32x8!(group, |b| {
+        bench_ultraviolet_f32x8!(group, size, |b, size| {
             use ultraviolet::Mat4x8;
             bench_binop_wide!(b, size, width => 8, op => mul, ty1 => Mat4x8, ty2 => Mat4x8)
         });
-        bench_nalgebra_f32x8!(group, |b| {
+        bench_nalgebra_f32x8!(group, size, |b, size| {
             use nalgebra::Matrix4;
             use simba::simd::f32x8;
             bench_binop_wide!(b, size, width => 8, op => mul, ty1 => Matrix4<f32x8>, ty2 => Matrix4<f32x8>)
@@ -333,24 +334,24 @@ fn bench_matrix4_mul_vector4_wide(c: &mut Criterion) {
     let mut group = c.benchmark_group("wide matrix4 mul vector4");
     for size in [16, 256].iter() {
         group.throughput(criterion::Throughput::Elements(*size as u64));
-        bench_glam_f32x1!(group, |b| {
+        bench_glam_f32x1!(group, size, |b, size| {
             use glam::{Mat4, Vec4};
             bench_binop_wide!(b, size, width => 1, op => mul, ty1 => Mat4, ty2 => Vec4)
         });
-        bench_ultraviolet_f32x4!(group, |b| {
+        bench_ultraviolet_f32x4!(group, size, |b, size| {
             use ultraviolet::{Mat4x4, Vec4x4};
             bench_binop_wide!(b, size, width => 4, op => mul, ty1 => Mat4x4, ty2 => Vec4x4)
         });
-        bench_nalgebra_f32x4!(group, |b| {
+        bench_nalgebra_f32x4!(group, size, |b, size| {
             use nalgebra::{Matrix4, Vector4};
             use simba::simd::f32x4;
             bench_binop_wide!(b, size, width => 4, op => mul, ty1 => Matrix4<f32x4>, ty2 => Vector4<f32x4>)
         });
-        bench_ultraviolet_f32x8!(group, |b| {
+        bench_ultraviolet_f32x8!(group, size, |b, size| {
             use ultraviolet::{Mat4x8, Vec4x8};
             bench_binop_wide!(b, size, width => 8, op => mul, ty1 => Mat4x8, ty2 => Vec4x8)
         });
-        bench_nalgebra_f32x8!(group, |b| {
+        bench_nalgebra_f32x8!(group, size, |b, size| {
             use nalgebra::{Matrix4, Vector4};
             use simba::simd::f32x8;
             bench_binop_wide!(b, size, width => 8, op => mul, ty1 => Matrix4<f32x8>, ty2 => Vector4<f32x8>)

--- a/benches/ray_sphere_intersect.rs
+++ b/benches/ray_sphere_intersect.rs
@@ -201,7 +201,7 @@ fn bench_ray_sphere_intersect_wide(c: &mut Criterion) {
     let mut group = c.benchmark_group("wide ray-sphere intersection");
     for size in [80000].iter() {
         group.throughput(Throughput::Elements(*size as u64));
-        bench_glam!(group, size, |b, size| {
+        bench_glam_f32x1!(group, size, |b, size| {
             use glam::Vec3;
             bench_intersection_scalar!(b, size, ty => Vec3, zero => Vec3::zero(), norm => normalize, mag_sq => length_squared, param => by_value);
         });

--- a/benches/rotation3.rs
+++ b/benches/rotation3.rs
@@ -2,6 +2,7 @@
 #[macro_use]
 mod macros;
 use criterion::{criterion_group, criterion_main, Criterion};
+use macros::MIN_WIDE_BENCH_SIZE;
 
 // returns self to check overhead of benchmark
 fn bench_rotation3_nop(c: &mut Criterion) {
@@ -36,27 +37,27 @@ fn bench_rotation3_nop(c: &mut Criterion) {
 
 fn bench_rotation3_nop_wide(c: &mut Criterion) {
     use mathbench::BenchValue;
-    let size = &macros::MIN_WIDE_BENCH_SIZE;
+    let size = &MIN_WIDE_BENCH_SIZE;
     let mut group = c.benchmark_group("wide rotation3 return self");
     group.throughput(criterion::Throughput::Elements(*size));
-    bench_glam_f32x1!(group, |b| {
+    bench_glam_f32x1!(group, size, |b, size| {
         use glam::Quat;
         bench_unop_wide!(b, size, width => 1, op => ret_self, ty => Quat)
     });
-    bench_ultraviolet_f32x4!(group, |b| {
+    bench_ultraviolet_f32x4!(group, size, |b, size| {
         use ultraviolet::Rotor3x4;
         bench_unop_wide!(b, size, width => 4, op => ret_self, ty => Rotor3x4)
     });
-    bench_nalgebra_f32x4!(group, |b| {
+    bench_nalgebra_f32x4!(group, size, |b, size| {
         use nalgebra::UnitQuaternion;
         use simba::simd::f32x4;
         bench_unop_wide!(b, size, width => 4, op => ret_self, ty => UnitQuaternion<f32x4>)
     });
-    bench_ultraviolet_f32x8!(group, |b| {
+    bench_ultraviolet_f32x8!(group, size, |b, size| {
         use ultraviolet::Rotor3x8;
         bench_unop_wide!(b, size, width => 8, op => ret_self, ty => Rotor3x8)
     });
-    bench_nalgebra_f32x8!(group, |b| {
+    bench_nalgebra_f32x8!(group, size, |b, size| {
         use nalgebra::UnitQuaternion;
         use simba::simd::f32x8;
         bench_unop_wide!(b, size, width => 8, op => ret_self, ty => UnitQuaternion<f32x8>)
@@ -100,27 +101,27 @@ fn bench_rotation3_inverse(c: &mut Criterion) {
 }
 
 fn bench_rotation3_inverse_wide(c: &mut Criterion) {
-    let size = &macros::MIN_WIDE_BENCH_SIZE;
+    let size = &MIN_WIDE_BENCH_SIZE;
     let mut group = c.benchmark_group("wide rotation3 inverse");
     group.throughput(criterion::Throughput::Elements(*size));
-    bench_glam_f32x1!(group, |b| {
+    bench_glam_f32x1!(group, size, |b, size| {
         use glam::Quat;
         bench_unop_wide!(b, size, width => 1, op => conjugate, ty => Quat)
     });
-    bench_ultraviolet_f32x4!(group, |b| {
+    bench_ultraviolet_f32x4!(group, size, |b, size| {
         use ultraviolet::Rotor3x4;
         bench_unop_wide!(b, size, width => 4, op => reversed, ty => Rotor3x4)
     });
-    bench_nalgebra_f32x4!(group, |b| {
+    bench_nalgebra_f32x4!(group, size, |b, size| {
         use nalgebra::UnitQuaternion;
         use simba::simd::f32x4;
         bench_unop_wide!(b, size, width => 4, op => conjugate, ty => UnitQuaternion<f32x4>)
     });
-    bench_ultraviolet_f32x8!(group, |b| {
+    bench_ultraviolet_f32x8!(group, size, |b, size| {
         use ultraviolet::Rotor3x8;
         bench_unop_wide!(b, size, width => 8, op => reversed, ty => Rotor3x8)
     });
-    bench_nalgebra_f32x8!(group, |b| {
+    bench_nalgebra_f32x8!(group, size, |b, size| {
         use nalgebra::UnitQuaternion;
         use simba::simd::f32x8;
         bench_unop_wide!(b, size, width => 8, op => conjugate, ty => UnitQuaternion<f32x8>)
@@ -164,27 +165,27 @@ fn bench_rotation3_mul_rotation3(c: &mut Criterion) {
 
 fn bench_rotation3_mul_rotation3_wide(c: &mut Criterion) {
     use std::ops::Mul;
-    let size = &macros::MIN_WIDE_BENCH_SIZE;
+    let size = &MIN_WIDE_BENCH_SIZE;
     let mut group = c.benchmark_group("wide rotation3 mul rotation3");
     group.throughput(criterion::Throughput::Elements(*size));
-    bench_glam_f32x1!(group, |b| {
+    bench_glam_f32x1!(group, size, |b, size| {
         use glam::Quat;
         bench_binop_wide!(b, size, width => 1, op => mul, ty1 => Quat, ty2 => Quat)
     });
-    bench_ultraviolet_f32x4!(group, |b| {
+    bench_ultraviolet_f32x4!(group, size, |b, size| {
         use ultraviolet::Rotor3x4;
         bench_binop_wide!(b, size, width => 4, op => mul, ty1 => Rotor3x4, ty2 => Rotor3x4)
     });
-    bench_nalgebra_f32x4!(group, |b| {
+    bench_nalgebra_f32x4!(group, size, |b, size| {
         use nalgebra::UnitQuaternion;
         use simba::simd::f32x4;
         bench_binop_wide!(b, size, width => 4, op => mul, ty1 => UnitQuaternion<f32x4>, ty2 => UnitQuaternion<f32x4>)
     });
-    bench_ultraviolet_f32x8!(group, |b| {
+    bench_ultraviolet_f32x8!(group, size, |b, size| {
         use ultraviolet::Rotor3x8;
         bench_binop_wide!(b, size, width => 8, op => mul, ty1 => Rotor3x8, ty2 => Rotor3x8)
     });
-    bench_nalgebra_f32x8!(group, |b| {
+    bench_nalgebra_f32x8!(group, size, |b, size| {
         use nalgebra::UnitQuaternion;
         use simba::simd::f32x8;
         bench_binop_wide!(b, size, width => 8, op => mul, ty1 => UnitQuaternion<f32x8>, ty2 => UnitQuaternion<f32x8>)
@@ -197,32 +198,32 @@ fn bench_rotation3_mul_vector3(c: &mut Criterion) {
     let mut group = c.benchmark_group("scalar rotation3 mul vector3");
     for size in [1, 100].iter() {
         group.throughput(criterion::Throughput::Elements(*size as u64));
-        bench_glam!(group, |b| {
+        bench_glam!(group, size, |b, size| {
             use glam::{Quat, Vec3};
             bench_binop!(b, size, op => mul, ty1 => Quat, ty2 => Vec3)
         });
-        bench_cgmath!(group, |b| {
+        bench_cgmath!(group, size, |b, size| {
             use cgmath::{Quaternion, Vector3};
             bench_binop!(b, size, op => mul, ty1 => Quaternion<f32>, ty2 => Vector3<f32>)
         });
-        bench_ultraviolet!(group, |b| {
+        bench_ultraviolet!(group, size, |b, size| {
             use ultraviolet::{Rotor3, Vec3};
             bench_binop!(b, size, op => mul, ty1 => Rotor3, ty2 => Vec3)
         });
-        bench_nalgebra!(group, |b| {
+        bench_nalgebra!(group, size, |b, size| {
             use nalgebra::{UnitQuaternion, Vector3};
             bench_binop!(b, size, op => mul, ty1 => UnitQuaternion<f32>, ty2 => Vector3<f32>)
         });
-        bench_static_math!(group, |b| {
+        bench_static_math!(group, size, |b, size| {
             use static_math::quaternion::Quaternion;
             use static_math::vector3::V3;
             bench_binop!(b, size, op => mul, ty1 => Quaternion<f32>, ty2 => V3<f32>)
         });
-        bench_euclid!(group, |b| {
+        bench_euclid!(group, size, |b, size| {
             use euclid::{Point3D, Rotation3D, UnknownUnit};
             bench_binop!(b, size, op => transform_point3d, ty1 => Rotation3D<f32, UnknownUnit, UnknownUnit>, ty2 => Point3D<f32, UnknownUnit>)
         });
-        bench_vek!(group, |b| {
+        bench_vek!(group, size, |b, size| {
             use vek::{Quaternion, Vec3};
             bench_binop!(b, size, op => mul, ty1 => Quaternion<f32>, ty2 => Vec3<f32>)
         });
@@ -232,27 +233,27 @@ fn bench_rotation3_mul_vector3(c: &mut Criterion) {
 
 fn bench_rotation3_mul_vector3_wide(c: &mut Criterion) {
     use std::ops::Mul;
-    let size = &macros::MIN_WIDE_BENCH_SIZE;
+    let size = &MIN_WIDE_BENCH_SIZE;
     let mut group = c.benchmark_group("wide rotation3 mul vector3");
     group.throughput(criterion::Throughput::Elements(*size));
-    bench_glam_f32x1!(group, |b| {
+    bench_glam_f32x1!(group, size, |b, size| {
         use glam::{Quat, Vec3};
         bench_binop_wide!(b, size, width => 1, op => mul, ty1 => Quat, ty2 => Vec3)
     });
-    bench_ultraviolet_f32x4!(group, |b| {
+    bench_ultraviolet_f32x4!(group, size, |b, size| {
         use ultraviolet::{Rotor3x4, Vec3x4};
         bench_binop_wide!(b, size, width => 4, op => mul, ty1 => Rotor3x4, ty2 => Vec3x4)
     });
-    bench_nalgebra_f32x4!(group, |b| {
+    bench_nalgebra_f32x4!(group, size, |b, size| {
         use nalgebra::{UnitQuaternion, Vector3};
         use simba::simd::f32x4;
         bench_binop_wide!(b, size, width => 4, op => mul, ty1 => UnitQuaternion<f32x4>, ty2 => Vector3<f32x4>)
     });
-    bench_ultraviolet_f32x8!(group, |b| {
+    bench_ultraviolet_f32x8!(group, size, |b, size| {
         use ultraviolet::{Rotor3x8, Vec3x8};
         bench_binop_wide!(b, size, width => 8, op => mul, ty1 => Rotor3x8, ty2 => Vec3x8)
     });
-    bench_nalgebra_f32x8!(group, |b| {
+    bench_nalgebra_f32x8!(group, size, |b, size| {
         use nalgebra::{UnitQuaternion, Vector3};
         use simba::simd::f32x8;
         bench_binop_wide!(b, size, width => 8, op => mul, ty1 => UnitQuaternion<f32x8>, ty2 => Vector3<f32x8>)

--- a/benches/rotation3.rs
+++ b/benches/rotation3.rs
@@ -36,28 +36,30 @@ fn bench_rotation3_nop(c: &mut Criterion) {
 
 fn bench_rotation3_nop_wide(c: &mut Criterion) {
     use mathbench::BenchValue;
+    let size = &macros::MIN_WIDE_BENCH_SIZE;
     let mut group = c.benchmark_group("wide rotation3 return self");
-    bench_glam!(group, |b| {
+    group.throughput(criterion::Throughput::Elements(*size));
+    bench_glam_f32x1!(group, |b| {
         use glam::Quat;
-        bench_unop_wide!(b, op => ret_self, ty => Quat)
+        bench_unop_wide!(b, size, width => 1, op => ret_self, ty => Quat)
     });
     bench_ultraviolet_f32x4!(group, |b| {
         use ultraviolet::Rotor3x4;
-        bench_unop_wide!(b, width => 4, op => ret_self, ty => Rotor3x4)
+        bench_unop_wide!(b, size, width => 4, op => ret_self, ty => Rotor3x4)
     });
     bench_nalgebra_f32x4!(group, |b| {
         use nalgebra::UnitQuaternion;
         use simba::simd::f32x4;
-        bench_unop_wide!(b, width => 4, op => ret_self, ty => UnitQuaternion<f32x4>)
+        bench_unop_wide!(b, size, width => 4, op => ret_self, ty => UnitQuaternion<f32x4>)
     });
     bench_ultraviolet_f32x8!(group, |b| {
         use ultraviolet::Rotor3x8;
-        bench_unop_wide!(b, width => 8, op => ret_self, ty => Rotor3x8)
+        bench_unop_wide!(b, size, width => 8, op => ret_self, ty => Rotor3x8)
     });
     bench_nalgebra_f32x8!(group, |b| {
         use nalgebra::UnitQuaternion;
         use simba::simd::f32x8;
-        bench_unop_wide!(b, width => 8, op => ret_self, ty => UnitQuaternion<f32x8>)
+        bench_unop_wide!(b, size, width => 8, op => ret_self, ty => UnitQuaternion<f32x8>)
     });
     group.finish();
 }
@@ -98,28 +100,30 @@ fn bench_rotation3_inverse(c: &mut Criterion) {
 }
 
 fn bench_rotation3_inverse_wide(c: &mut Criterion) {
+    let size = &macros::MIN_WIDE_BENCH_SIZE;
     let mut group = c.benchmark_group("wide rotation3 inverse");
-    bench_glam!(group, |b| {
+    group.throughput(criterion::Throughput::Elements(*size));
+    bench_glam_f32x1!(group, |b| {
         use glam::Quat;
-        bench_unop_wide!(b, op => conjugate, ty => Quat)
+        bench_unop_wide!(b, size, width => 1, op => conjugate, ty => Quat)
     });
     bench_ultraviolet_f32x4!(group, |b| {
         use ultraviolet::Rotor3x4;
-        bench_unop_wide!(b, width => 4, op => reversed, ty => Rotor3x4)
+        bench_unop_wide!(b, size, width => 4, op => reversed, ty => Rotor3x4)
     });
     bench_nalgebra_f32x4!(group, |b| {
         use nalgebra::UnitQuaternion;
         use simba::simd::f32x4;
-        bench_unop_wide!(b, width => 4, op => conjugate, ty => UnitQuaternion<f32x4>)
+        bench_unop_wide!(b, size, width => 4, op => conjugate, ty => UnitQuaternion<f32x4>)
     });
     bench_ultraviolet_f32x8!(group, |b| {
         use ultraviolet::Rotor3x8;
-        bench_unop_wide!(b, width => 8, op => reversed, ty => Rotor3x8)
+        bench_unop_wide!(b, size, width => 8, op => reversed, ty => Rotor3x8)
     });
     bench_nalgebra_f32x8!(group, |b| {
         use nalgebra::UnitQuaternion;
         use simba::simd::f32x8;
-        bench_unop_wide!(b, width => 8, op => conjugate, ty => UnitQuaternion<f32x8>)
+        bench_unop_wide!(b, size, width => 8, op => conjugate, ty => UnitQuaternion<f32x8>)
     });
     group.finish();
 }
@@ -160,28 +164,30 @@ fn bench_rotation3_mul_rotation3(c: &mut Criterion) {
 
 fn bench_rotation3_mul_rotation3_wide(c: &mut Criterion) {
     use std::ops::Mul;
+    let size = &macros::MIN_WIDE_BENCH_SIZE;
     let mut group = c.benchmark_group("wide rotation3 mul rotation3");
-    bench_glam!(group, |b| {
+    group.throughput(criterion::Throughput::Elements(*size));
+    bench_glam_f32x1!(group, |b| {
         use glam::Quat;
-        bench_binop_wide!(b, width => 1, op => mul, ty1 => Quat, ty2 => Quat)
+        bench_binop_wide!(b, size, width => 1, op => mul, ty1 => Quat, ty2 => Quat)
     });
     bench_ultraviolet_f32x4!(group, |b| {
         use ultraviolet::Rotor3x4;
-        bench_binop_wide!(b, width => 4, op => mul, ty1 => Rotor3x4, ty2 => Rotor3x4)
+        bench_binop_wide!(b, size, width => 4, op => mul, ty1 => Rotor3x4, ty2 => Rotor3x4)
     });
     bench_nalgebra_f32x4!(group, |b| {
         use nalgebra::UnitQuaternion;
         use simba::simd::f32x4;
-        bench_binop_wide!(b, width => 4, op => mul, ty1 => UnitQuaternion<f32x4>, ty2 => UnitQuaternion<f32x4>)
+        bench_binop_wide!(b, size, width => 4, op => mul, ty1 => UnitQuaternion<f32x4>, ty2 => UnitQuaternion<f32x4>)
     });
     bench_ultraviolet_f32x8!(group, |b| {
         use ultraviolet::Rotor3x8;
-        bench_binop_wide!(b, width => 8, op => mul, ty1 => Rotor3x8, ty2 => Rotor3x8)
+        bench_binop_wide!(b, size, width => 8, op => mul, ty1 => Rotor3x8, ty2 => Rotor3x8)
     });
     bench_nalgebra_f32x8!(group, |b| {
         use nalgebra::UnitQuaternion;
         use simba::simd::f32x8;
-        bench_binop_wide!(b, width => 8, op => mul, ty1 => UnitQuaternion<f32x8>, ty2 => UnitQuaternion<f32x8>)
+        bench_binop_wide!(b, size, width => 8, op => mul, ty1 => UnitQuaternion<f32x8>, ty2 => UnitQuaternion<f32x8>)
     });
     group.finish();
 }
@@ -226,28 +232,30 @@ fn bench_rotation3_mul_vector3(c: &mut Criterion) {
 
 fn bench_rotation3_mul_vector3_wide(c: &mut Criterion) {
     use std::ops::Mul;
+    let size = &macros::MIN_WIDE_BENCH_SIZE;
     let mut group = c.benchmark_group("wide rotation3 mul vector3");
-    bench_glam!(group, |b| {
+    group.throughput(criterion::Throughput::Elements(*size));
+    bench_glam_f32x1!(group, |b| {
         use glam::{Quat, Vec3};
-        bench_binop_wide!(b, width => 1, op => mul, ty1 => Quat, ty2 => Vec3)
+        bench_binop_wide!(b, size, width => 1, op => mul, ty1 => Quat, ty2 => Vec3)
     });
     bench_ultraviolet_f32x4!(group, |b| {
         use ultraviolet::{Rotor3x4, Vec3x4};
-        bench_binop_wide!(b, width => 4, op => mul, ty1 => Rotor3x4, ty2 => Vec3x4)
+        bench_binop_wide!(b, size, width => 4, op => mul, ty1 => Rotor3x4, ty2 => Vec3x4)
     });
     bench_nalgebra_f32x4!(group, |b| {
         use nalgebra::{UnitQuaternion, Vector3};
         use simba::simd::f32x4;
-        bench_binop_wide!(b, width => 4, op => mul, ty1 => UnitQuaternion<f32x4>, ty2 => Vector3<f32x4>)
+        bench_binop_wide!(b, size, width => 4, op => mul, ty1 => UnitQuaternion<f32x4>, ty2 => Vector3<f32x4>)
     });
     bench_ultraviolet_f32x8!(group, |b| {
         use ultraviolet::{Rotor3x8, Vec3x8};
-        bench_binop_wide!(b, width => 8, op => mul, ty1 => Rotor3x8, ty2 => Vec3x8)
+        bench_binop_wide!(b, size, width => 8, op => mul, ty1 => Rotor3x8, ty2 => Vec3x8)
     });
     bench_nalgebra_f32x8!(group, |b| {
         use nalgebra::{UnitQuaternion, Vector3};
         use simba::simd::f32x8;
-        bench_binop_wide!(b, width => 8, op => mul, ty1 => UnitQuaternion<f32x8>, ty2 => Vector3<f32x8>)
+        bench_binop_wide!(b, size, width => 8, op => mul, ty1 => UnitQuaternion<f32x8>, ty2 => Vector3<f32x8>)
     });
     group.finish();
 }

--- a/benches/support/macros.rs
+++ b/benches/support/macros.rs
@@ -1,3 +1,6 @@
+#[allow(dead_code)]
+pub const MIN_WIDE_BENCH_SIZE: u64 = 16;
+
 #[macro_export]
 macro_rules! bench_lib {
     ($libname:literal, $group:ident, $size:expr, $closure:expr) => {
@@ -23,6 +26,16 @@ macro_rules! bench_glam {
     ($group:ident, $size:expr, $closure:expr) => {
         // bench_lib!("glam", $group, $size, $closure)
         $group.bench_with_input(criterion::BenchmarkId::new("glam", $size), $size, $closure)
+    };
+}
+
+#[macro_export]
+macro_rules! bench_glam_f32x1 {
+    ($group:ident, $closure:expr) => {
+        $group.bench_function("glam_f32x1", $closure)
+    };
+    ($group:ident, $size:expr, $closure:expr) => {
+        $group.bench_with_input(criterion::BenchmarkId::new("glam_f32x1", $size), $size, $closure)
     };
 }
 
@@ -247,9 +260,10 @@ macro_rules! bench_unop {
 
 #[macro_export]
 macro_rules! bench_unop_wide {
-    ($b: ident, width => $width: expr, op => $unop: ident, ty => $t:ty) => {{
+    ($b: ident, $size: expr, width => $width: expr, op => $unop: ident, ty => $t:ty) => {{
         const SIZE: usize = 1 << 13;
-        let batch_size = (16.0 / $width as f32).ceil() as usize;
+        let size = *$size as f32;
+        let batch_size = (size / $width as f32).ceil() as usize;
         let total_size = SIZE * batch_size;
 
         let mut rng = rand_pcg::Pcg64Mcg::new(rand::random());
@@ -273,9 +287,6 @@ macro_rules! bench_unop_wide {
             }
         });
         criterion::black_box(outputs);
-    }};
-    ($b: ident, op => $unop: ident, ty => $t:ty) => {{
-        bench_unop_wide!($b, width => 1, op => $unop, ty => $t)
     }};
 }
 
@@ -356,7 +367,7 @@ macro_rules! bench_binop {
 macro_rules! bench_binop_wide {
     ($b: ident, $size:expr, width => $width: expr, op => $binop: ident, ty1 => $t1:ty, ty2 => $t2:ty, param => $param:tt) => {{
         assert!(*$size >= 16);
-        let size = *$size;
+        let size = *$size as usize;
 
         let batch_size = (size as f32 / $width as f32).ceil() as usize;
         const SIZE: usize = 1 << 13;
@@ -388,14 +399,8 @@ macro_rules! bench_binop_wide {
             }
         })
     }};
-    ($b: ident, width => $width: expr, op => $binop: ident, ty1 => $t1:ty, ty2 => $t2:ty, param => $param:tt) => {{
-        bench_binop_wide!($b, &16, width => $width, op => $binop, ty1 => $t1, ty2 => $t2, param => $param)
-    }};
     ($b: ident, $size:expr, width => $width: expr, op => $binop: ident, ty1 => $ty1:ty, ty2 => $ty2:ty) => {{
         bench_binop_wide!($b, $size, width => $width, op => $binop, ty1 => $ty1, ty2 => $ty2, param => by_value)
-    }};
-    ($b: ident, width => $width: expr, op => $binop: ident, ty1 => $ty1:ty, ty2 => $ty2:ty) => {{
-        bench_binop_wide!($b, &16, width => $width, op => $binop, ty1 => $ty1, ty2 => $ty2, param => by_value)
     }};
 }
 

--- a/benches/support/macros.rs
+++ b/benches/support/macros.rs
@@ -31,11 +31,15 @@ macro_rules! bench_glam {
 
 #[macro_export]
 macro_rules! bench_glam_f32x1 {
-    ($group:ident, $closure:expr) => {
-        $group.bench_function("glam_f32x1", $closure)
-    };
+    // ($group:ident, $closure:expr) => {
+    //     $group.bench_function("glam_f32x1", $closure)
+    // };
     ($group:ident, $size:expr, $closure:expr) => {
-        $group.bench_with_input(criterion::BenchmarkId::new("glam_f32x1", $size), $size, $closure)
+        $group.bench_with_input(
+            criterion::BenchmarkId::new("glam_f32x1", $size),
+            $size,
+            $closure,
+        )
     };
 }
 
@@ -61,9 +65,9 @@ macro_rules! bench_ultraviolet {
 
 #[macro_export]
 macro_rules! bench_ultraviolet_f32x4 {
-    ($group:ident, $closure:expr) => {
-        bench_lib!("ultraviolet_f32x4", $group, $closure)
-    };
+    // ($group:ident, $closure:expr) => {
+    //     bench_lib!("ultraviolet_f32x4", $group, $closure)
+    // };
     ($group:ident, $size:expr, $closure:expr) => {
         bench_lib!("ultraviolet_f32x4", $group, $size, $closure)
     };
@@ -71,9 +75,9 @@ macro_rules! bench_ultraviolet_f32x4 {
 
 #[macro_export]
 macro_rules! bench_ultraviolet_f32x8 {
-    ($group:ident, $closure:expr) => {
-        bench_lib!("ultraviolet_f32x8", $group, $closure)
-    };
+    // ($group:ident, $closure:expr) => {
+    //     bench_lib!("ultraviolet_f32x8", $group, $closure)
+    // };
     ($group:ident, $size:expr, $closure:expr) => {
         bench_lib!("ultraviolet_f32x8", $group, $size, $closure)
     };
@@ -81,9 +85,9 @@ macro_rules! bench_ultraviolet_f32x8 {
 
 #[macro_export]
 macro_rules! bench_ultraviolet_f64 {
-    ($group:ident, $closure:expr) => {
-        bench_lib!("ultraviolet_f64", $group, $closure)
-    };
+    // ($group:ident, $closure:expr) => {
+    //     bench_lib!("ultraviolet_f64", $group, $closure)
+    // };
     ($group:ident, $size:expr, $closure:expr) => {
         bench_lib!("ultraviolet_f64", $group, $size, $closure)
     };
@@ -91,9 +95,9 @@ macro_rules! bench_ultraviolet_f64 {
 
 #[macro_export]
 macro_rules! bench_ultraviolet_f64x2 {
-    ($group:ident, $closure:expr) => {
-        bench_lib!("ultraviolet_f64x2", $group, $closure)
-    };
+    // ($group:ident, $closure:expr) => {
+    //     bench_lib!("ultraviolet_f64x2", $group, $closure)
+    // };
     ($group:ident, $size:expr, $closure:expr) => {
         bench_lib!("ultraviolet_f64x2", $group, $size, $closure)
     };
@@ -101,9 +105,9 @@ macro_rules! bench_ultraviolet_f64x2 {
 
 #[macro_export]
 macro_rules! bench_ultraviolet_f64x4 {
-    ($group:ident, $closure:expr) => {
-        bench_lib!("ultraviolet_f64x4", $group, $closure)
-    };
+    // ($group:ident, $closure:expr) => {
+    //     bench_lib!("ultraviolet_f64x4", $group, $closure)
+    // };
     ($group:ident, $size:expr, $closure:expr) => {
         bench_lib!("ultraviolet_f64x4", $group, $size, $closure)
     };
@@ -121,9 +125,9 @@ macro_rules! bench_nalgebra {
 
 #[macro_export]
 macro_rules! bench_nalgebra_f32x4 {
-    ($group:ident, $closure:expr) => {
-        bench_lib!("nalgebra_f32x4", $group, $closure)
-    };
+    // ($group:ident, $closure:expr) => {
+    //     bench_lib!("nalgebra_f32x4", $group, $closure)
+    // };
     ($group:ident, $size:expr, $closure:expr) => {
         bench_lib!("nalgebra_f32x4", $group, $size, $closure)
     };
@@ -131,9 +135,9 @@ macro_rules! bench_nalgebra_f32x4 {
 
 #[macro_export]
 macro_rules! bench_nalgebra_f32x8 {
-    ($group:ident, $closure:expr) => {
-        bench_lib!("nalgebra_f32x8", $group, $closure)
-    };
+    // ($group:ident, $closure:expr) => {
+    //     bench_lib!("nalgebra_f32x8", $group, $closure)
+    // };
     ($group:ident, $size:expr, $closure:expr) => {
         bench_lib!("nalgebra_f32x8", $group, $size, $closure)
     };
@@ -141,9 +145,9 @@ macro_rules! bench_nalgebra_f32x8 {
 
 #[macro_export]
 macro_rules! bench_nalgebra_f32x16 {
-    ($group:ident, $closure:expr) => {
-        bench_lib!("nalgebra_f32x16", $group, $closure)
-    };
+    // ($group:ident, $closure:expr) => {
+    //     bench_lib!("nalgebra_f32x16", $group, $closure)
+    // };
     ($group:ident, $size:expr, $closure:expr) => {
         bench_lib!("nalgebra_f32x16", $group, $size, $closure)
     };
@@ -161,9 +165,9 @@ macro_rules! bench_nalgebra_f64 {
 
 #[macro_export]
 macro_rules! bench_nalgebra_f64x2 {
-    ($group:ident, $closure:expr) => {
-        bench_lib!("nalgebra_f64x2", $group, $closure)
-    };
+    // ($group:ident, $closure:expr) => {
+    //     bench_lib!("nalgebra_f64x2", $group, $closure)
+    // };
     ($group:ident, $size:expr, $closure:expr) => {
         bench_lib!("nalgebra_f64x2", $group, $size, $closure)
     };
@@ -171,9 +175,9 @@ macro_rules! bench_nalgebra_f64x2 {
 
 #[macro_export]
 macro_rules! bench_nalgebra_f64x4 {
-    ($group:ident, $closure:expr) => {
-        bench_lib!("nalgebra_f64x4", $group, $closure)
-    };
+    // ($group:ident, $closure:expr) => {
+    //     bench_lib!("nalgebra_f64x4", $group, $closure)
+    // };
     ($group:ident, $size:expr, $closure:expr) => {
         bench_lib!("nalgebra_f64x4", $group, $size, $closure)
     };
@@ -181,9 +185,9 @@ macro_rules! bench_nalgebra_f64x4 {
 
 #[macro_export]
 macro_rules! bench_nalgebra_f64x8 {
-    ($group:ident, $closure:expr) => {
-        bench_lib!("nalgebra_f64x8", $group, $closure)
-    };
+    // ($group:ident, $closure:expr) => {
+    //     bench_lib!("nalgebra_f64x8", $group, $closure)
+    // };
     ($group:ident, $size:expr, $closure:expr) => {
         bench_lib!("nalgebra_f64x8", $group, $size, $closure)
     };
@@ -273,7 +277,8 @@ macro_rules! bench_unop_wide {
                 .collect::<Vec<_>>(),
         );
         // pre-fill output vector with some random value
-        let mut outputs = vec![<$t as mathbench::BenchValue>::random_value(&mut rng).$unop(); total_size];
+        let mut outputs =
+            vec![<$t as mathbench::BenchValue>::random_value(&mut rng).$unop(); total_size];
         let mut i = 0;
         $b.iter(|| {
             // minimise overhead of accessing random data using get unchecked
@@ -283,7 +288,9 @@ macro_rules! bench_unop_wide {
             for j in start..end {
                 let res = unsafe { inputs.get_unchecked(j).$unop() };
                 criterion::black_box(res);
-                unsafe { *outputs.get_unchecked_mut(j) = res; }
+                unsafe {
+                    *outputs.get_unchecked_mut(j) = res;
+                }
             }
         });
         criterion::black_box(outputs);

--- a/benches/transformations.rs
+++ b/benches/transformations.rs
@@ -39,7 +39,7 @@ fn bench_transform_vector3_wide(c: &mut Criterion) {
     let mut group = c.benchmark_group("wide transform vector3");
     for size in [16, 256].iter() {
         group.throughput(criterion::Throughput::Elements(*size as u64));
-        bench_glam!(group, size, |b, size| {
+        bench_glam_f32x1!(group, size, |b, size| {
             use glam::{Mat4, Vec3};
             bench_binop_wide!(b, size, width => 1, op => transform_vector3, ty1 => Mat4, ty2 => Vec3)
         });
@@ -97,7 +97,7 @@ fn bench_transform_point3_wide(c: &mut Criterion) {
     let mut group = c.benchmark_group("wide transform point3");
     for size in [16, 256].iter() {
         group.throughput(criterion::Throughput::Elements(*size as u64));
-        bench_glam!(group, size, |b, size| {
+        bench_glam_f32x1!(group, size, |b, size| {
             use glam::{Mat4, Vec3};
             bench_binop_wide!(b, size, width => 1, op => transform_point3, ty1 => Mat4, ty2 => Vec3)
         });
@@ -155,7 +155,7 @@ fn bench_transform_point2_wide(c: &mut Criterion) {
     let mut group = c.benchmark_group("wide transform point2");
     for size in [16, 256].iter() {
         group.throughput(criterion::Throughput::Elements(*size as u64));
-        bench_glam!(group, size, |b, size| {
+        bench_glam_f32x1!(group, size, |b, size| {
             use glam::{Mat3, Vec2};
             bench_binop_wide!(b, size, width => 1, op => transform_point2, ty1 => Mat3, ty2 => Vec2)
         });
@@ -208,7 +208,7 @@ fn bench_transform_vector2_wide(c: &mut Criterion) {
     let mut group = c.benchmark_group("wide transform vector2");
     for size in [16, 256].iter() {
         group.throughput(criterion::Throughput::Elements(*size as u64));
-        bench_glam!(group, size, |b, size| {
+        bench_glam_f32x1!(group, size, |b, size| {
             use glam::{Mat3, Vec2};
             bench_binop_wide!(b, size, width => 1, op => transform_vector2, ty1 => Mat3, ty2 => Vec2)
         });

--- a/benches/vector3.rs
+++ b/benches/vector3.rs
@@ -36,28 +36,30 @@ fn bench_vector3_ret_self(c: &mut Criterion) {
 
 fn bench_vector3_ret_self_wide(c: &mut Criterion) {
     use mathbench::BenchValue;
+    let size = &macros::MIN_WIDE_BENCH_SIZE;
     let mut group = c.benchmark_group("wide vector3 return self");
-    bench_glam!(group, |b| {
+    group.throughput(criterion::Throughput::Elements(*size));
+    bench_glam_f32x1!(group, |b| {
         use glam::Vec3A;
-        bench_unop_wide!(b, op => ret_self, ty => Vec3A)
+        bench_unop_wide!(b, size, width => 1, op => ret_self, ty => Vec3A)
     });
     bench_ultraviolet_f32x4!(group, |b| {
         use ultraviolet::Vec3x4;
-        bench_unop_wide!(b, width => 4, op => ret_self, ty => Vec3x4)
+        bench_unop_wide!(b, size, width => 4, op => ret_self, ty => Vec3x4)
     });
     bench_nalgebra_f32x4!(group, |b| {
         use nalgebra::Vector3;
         use simba::simd::f32x4;
-        bench_unop_wide!(b, width => 4, op => ret_self, ty => Vector3<f32x4>)
+        bench_unop_wide!(b, size, width => 4, op => ret_self, ty => Vector3<f32x4>)
     });
     bench_ultraviolet_f32x8!(group, |b| {
         use ultraviolet::Vec3x8;
-        bench_unop_wide!(b, width => 8, op => ret_self, ty => Vec3x8)
+        bench_unop_wide!(b, size, width => 8, op => ret_self, ty => Vec3x8)
     });
     bench_nalgebra_f32x8!(group, |b| {
         use nalgebra::Vector3;
         use simba::simd::f32x8;
-        bench_unop_wide!(b, width => 8, op => ret_self, ty => Vector3<f32x8>)
+        bench_unop_wide!(b, size, width => 8, op => ret_self, ty => Vector3<f32x8>)
     });
     group.finish();
 }
@@ -96,28 +98,30 @@ fn bench_vector3_length(c: &mut Criterion) {
 }
 
 fn bench_vector3_length_wide(c: &mut Criterion) {
+    let size = &macros::MIN_WIDE_BENCH_SIZE;
     let mut group = c.benchmark_group("wide vector3 length");
-    bench_glam!(group, |b| {
+    group.throughput(criterion::Throughput::Elements(*size));
+    bench_glam_f32x1!(group, |b| {
         use glam::Vec3A;
-        bench_unop_wide!(b, op => length, ty => Vec3A)
+        bench_unop_wide!(b, size, width => 1, op => length, ty => Vec3A)
     });
     bench_ultraviolet_f32x4!(group, |b| {
         use ultraviolet::Vec3x4;
-        bench_unop_wide!(b, width => 4, op => mag, ty => Vec3x4)
+        bench_unop_wide!(b, size, width => 4, op => mag, ty => Vec3x4)
     });
     bench_nalgebra_f32x4!(group, |b| {
         use nalgebra::Vector3;
         use simba::simd::f32x4;
-        bench_unop_wide!(b, width => 4, op => norm, ty => Vector3<f32x4>)
+        bench_unop_wide!(b, size, width => 4, op => norm, ty => Vector3<f32x4>)
     });
     bench_ultraviolet_f32x8!(group, |b| {
         use ultraviolet::Vec3x8;
-        bench_unop_wide!(b, width => 8, op => mag, ty => Vec3x8)
+        bench_unop_wide!(b, size, width => 8, op => mag, ty => Vec3x8)
     });
     bench_nalgebra_f32x8!(group, |b| {
         use nalgebra::Vector3;
         use simba::simd::f32x8;
-        bench_unop_wide!(b, width => 8, op => norm, ty => Vector3<f32x8>)
+        bench_unop_wide!(b, size, width => 8, op => norm, ty => Vector3<f32x8>)
     });
     group.finish();
 }
@@ -152,28 +156,30 @@ fn bench_vector3_normalize(c: &mut Criterion) {
 }
 
 fn bench_vector3_normalize_wide(c: &mut Criterion) {
+    let size = &macros::MIN_WIDE_BENCH_SIZE;
     let mut group = c.benchmark_group("wide vector3 normalize");
-    bench_glam!(group, |b| {
+    group.throughput(criterion::Throughput::Elements(*size));
+    bench_glam_f32x1!(group, |b| {
         use glam::Vec3A;
-        bench_unop_wide!(b, op => normalize, ty => Vec3A)
+        bench_unop_wide!(b, size, width => 1, op => normalize, ty => Vec3A)
     });
     bench_ultraviolet_f32x4!(group, |b| {
         use ultraviolet::Vec3x4;
-        bench_unop_wide!(b, width => 4, op => normalized, ty => Vec3x4)
+        bench_unop_wide!(b, size, width => 4, op => normalized, ty => Vec3x4)
     });
     bench_nalgebra_f32x4!(group, |b| {
         use nalgebra::Vector3;
         use simba::simd::f32x4;
-        bench_unop_wide!(b, width => 4, op => normalize, ty => Vector3<f32x4>)
+        bench_unop_wide!(b, size, width => 4, op => normalize, ty => Vector3<f32x4>)
     });
     bench_ultraviolet_f32x8!(group, |b| {
         use ultraviolet::Vec3x8;
-        bench_unop_wide!(b, width => 8, op => normalized, ty => Vec3x8)
+        bench_unop_wide!(b, size, width => 8, op => normalized, ty => Vec3x8)
     });
     bench_nalgebra_f32x8!(group, |b| {
         use nalgebra::Vector3;
         use simba::simd::f32x8;
-        bench_unop_wide!(b, width => 8, op => normalize, ty => Vector3<f32x8>)
+        bench_unop_wide!(b, size, width => 8, op => normalize, ty => Vector3<f32x8>)
     });
     group.finish();
 }
@@ -213,28 +219,30 @@ fn bench_vector3_dot(c: &mut Criterion) {
 }
 
 fn bench_vector3_dot_wide(c: &mut Criterion) {
+    let size = &macros::MIN_WIDE_BENCH_SIZE;
     let mut group = c.benchmark_group("wide vector3 dot");
-    bench_glam!(group, |b| {
+    group.throughput(criterion::Throughput::Elements(*size));
+    bench_glam_f32x1!(group, |b| {
         use glam::Vec3A;
-        bench_binop_wide!(b, width => 1, op => dot, ty1 => Vec3A, ty2 => Vec3A)
+        bench_binop_wide!(b, size, width => 1, op => dot, ty1 => Vec3A, ty2 => Vec3A)
     });
     bench_ultraviolet_f32x4!(group, |b| {
         use ultraviolet::Vec3x4;
-        bench_binop_wide!(b, width => 4, op => dot, ty1 => Vec3x4, ty2 => Vec3x4)
+        bench_binop_wide!(b, size, width => 4, op => dot, ty1 => Vec3x4, ty2 => Vec3x4)
     });
     bench_nalgebra_f32x4!(group, |b| {
         use nalgebra::Vector3;
         use simba::simd::f32x4;
-        bench_binop_wide!(b, width => 4, op => dot, ty1 => Vector3<f32x4>, ty2 => Vector3<f32x4>, param => by_ref)
+        bench_binop_wide!(b, size, width => 4, op => dot, ty1 => Vector3<f32x4>, ty2 => Vector3<f32x4>, param => by_ref)
     });
     bench_ultraviolet_f32x8!(group, |b| {
         use ultraviolet::Vec3x8;
-        bench_binop_wide!(b, width => 8, op => dot, ty1 => Vec3x8, ty2 => Vec3x8)
+        bench_binop_wide!(b, size, width => 8, op => dot, ty1 => Vec3x8, ty2 => Vec3x8)
     });
     bench_nalgebra_f32x8!(group, |b| {
         use nalgebra::Vector3;
         use simba::simd::f32x8;
-        bench_binop_wide!(b, width => 8, op => dot, ty1 => Vector3<f32x8>, ty2 => Vector3<f32x8>, param => by_ref)
+        bench_binop_wide!(b, size, width => 8, op => dot, ty1 => Vector3<f32x8>, ty2 => Vector3<f32x8>, param => by_ref)
     });
     group.finish();
 }
@@ -273,28 +281,30 @@ fn bench_vector3_cross(c: &mut Criterion) {
 }
 
 fn bench_vector3_cross_wide(c: &mut Criterion) {
+    let size = &macros::MIN_WIDE_BENCH_SIZE;
     let mut group = c.benchmark_group("wide vector3 cross");
-    bench_glam!(group, |b| {
+    group.throughput(criterion::Throughput::Elements(*size));
+    bench_glam_f32x1!(group, |b| {
         use glam::Vec3A;
-        bench_binop_wide!(b, width => 1, op => cross, ty1 => Vec3A, ty2 => Vec3A)
+        bench_binop_wide!(b, size, width => 1, op => cross, ty1 => Vec3A, ty2 => Vec3A)
     });
     bench_ultraviolet_f32x4!(group, |b| {
         use ultraviolet::Vec3x4;
-        bench_binop_wide!(b, width => 4, op => cross, ty1 => Vec3x4, ty2 => Vec3x4)
+        bench_binop_wide!(b, size, width => 4, op => cross, ty1 => Vec3x4, ty2 => Vec3x4)
     });
     bench_nalgebra_f32x4!(group, |b| {
         use nalgebra::Vector3;
         use simba::simd::f32x4;
-        bench_binop_wide!(b, width => 4, op => cross, ty1 => Vector3<f32x4>, ty2 => Vector3<f32x4>, param => by_ref)
+        bench_binop_wide!(b, size, width => 4, op => cross, ty1 => Vector3<f32x4>, ty2 => Vector3<f32x4>, param => by_ref)
     });
     bench_ultraviolet_f32x8!(group, |b| {
         use ultraviolet::Vec3x8;
-        bench_binop_wide!(b, width => 8, op => cross, ty1 => Vec3x8, ty2 => Vec3x8)
+        bench_binop_wide!(b, size, width => 8, op => cross, ty1 => Vec3x8, ty2 => Vec3x8)
     });
     bench_nalgebra_f32x8!(group, |b| {
         use nalgebra::Vector3;
         use simba::simd::f32x8;
-        bench_binop_wide!(b, width => 8, op => cross, ty1 => Vector3<f32x8>, ty2 => Vector3<f32x8>, param => by_ref)
+        bench_binop_wide!(b, size, width => 8, op => cross, ty1 => Vector3<f32x8>, ty2 => Vector3<f32x8>, param => by_ref)
     });
     group.finish();
 }

--- a/benches/vector3.rs
+++ b/benches/vector3.rs
@@ -2,6 +2,7 @@
 #[macro_use]
 mod macros;
 use criterion::{criterion_group, criterion_main, Criterion};
+use macros::MIN_WIDE_BENCH_SIZE;
 
 // returns self to check overhead of benchmark
 fn bench_vector3_ret_self(c: &mut Criterion) {
@@ -36,27 +37,27 @@ fn bench_vector3_ret_self(c: &mut Criterion) {
 
 fn bench_vector3_ret_self_wide(c: &mut Criterion) {
     use mathbench::BenchValue;
-    let size = &macros::MIN_WIDE_BENCH_SIZE;
+    let size = &MIN_WIDE_BENCH_SIZE;
     let mut group = c.benchmark_group("wide vector3 return self");
     group.throughput(criterion::Throughput::Elements(*size));
-    bench_glam_f32x1!(group, |b| {
+    bench_glam_f32x1!(group, size, |b, size| {
         use glam::Vec3A;
         bench_unop_wide!(b, size, width => 1, op => ret_self, ty => Vec3A)
     });
-    bench_ultraviolet_f32x4!(group, |b| {
+    bench_ultraviolet_f32x4!(group, size, |b, size| {
         use ultraviolet::Vec3x4;
         bench_unop_wide!(b, size, width => 4, op => ret_self, ty => Vec3x4)
     });
-    bench_nalgebra_f32x4!(group, |b| {
+    bench_nalgebra_f32x4!(group, size, |b, size| {
         use nalgebra::Vector3;
         use simba::simd::f32x4;
         bench_unop_wide!(b, size, width => 4, op => ret_self, ty => Vector3<f32x4>)
     });
-    bench_ultraviolet_f32x8!(group, |b| {
+    bench_ultraviolet_f32x8!(group, size, |b, size| {
         use ultraviolet::Vec3x8;
         bench_unop_wide!(b, size, width => 8, op => ret_self, ty => Vec3x8)
     });
-    bench_nalgebra_f32x8!(group, |b| {
+    bench_nalgebra_f32x8!(group, size, |b, size| {
         use nalgebra::Vector3;
         use simba::simd::f32x8;
         bench_unop_wide!(b, size, width => 8, op => ret_self, ty => Vector3<f32x8>)
@@ -98,27 +99,27 @@ fn bench_vector3_length(c: &mut Criterion) {
 }
 
 fn bench_vector3_length_wide(c: &mut Criterion) {
-    let size = &macros::MIN_WIDE_BENCH_SIZE;
+    let size = &MIN_WIDE_BENCH_SIZE;
     let mut group = c.benchmark_group("wide vector3 length");
     group.throughput(criterion::Throughput::Elements(*size));
-    bench_glam_f32x1!(group, |b| {
+    bench_glam_f32x1!(group, size, |b, size| {
         use glam::Vec3A;
         bench_unop_wide!(b, size, width => 1, op => length, ty => Vec3A)
     });
-    bench_ultraviolet_f32x4!(group, |b| {
+    bench_ultraviolet_f32x4!(group, size, |b, size| {
         use ultraviolet::Vec3x4;
         bench_unop_wide!(b, size, width => 4, op => mag, ty => Vec3x4)
     });
-    bench_nalgebra_f32x4!(group, |b| {
+    bench_nalgebra_f32x4!(group, size, |b, size| {
         use nalgebra::Vector3;
         use simba::simd::f32x4;
         bench_unop_wide!(b, size, width => 4, op => norm, ty => Vector3<f32x4>)
     });
-    bench_ultraviolet_f32x8!(group, |b| {
+    bench_ultraviolet_f32x8!(group, size, |b, size| {
         use ultraviolet::Vec3x8;
         bench_unop_wide!(b, size, width => 8, op => mag, ty => Vec3x8)
     });
-    bench_nalgebra_f32x8!(group, |b| {
+    bench_nalgebra_f32x8!(group, size, |b, size| {
         use nalgebra::Vector3;
         use simba::simd::f32x8;
         bench_unop_wide!(b, size, width => 8, op => norm, ty => Vector3<f32x8>)
@@ -156,27 +157,27 @@ fn bench_vector3_normalize(c: &mut Criterion) {
 }
 
 fn bench_vector3_normalize_wide(c: &mut Criterion) {
-    let size = &macros::MIN_WIDE_BENCH_SIZE;
+    let size = &MIN_WIDE_BENCH_SIZE;
     let mut group = c.benchmark_group("wide vector3 normalize");
     group.throughput(criterion::Throughput::Elements(*size));
-    bench_glam_f32x1!(group, |b| {
+    bench_glam_f32x1!(group, size, |b, size| {
         use glam::Vec3A;
         bench_unop_wide!(b, size, width => 1, op => normalize, ty => Vec3A)
     });
-    bench_ultraviolet_f32x4!(group, |b| {
+    bench_ultraviolet_f32x4!(group, size, |b, size| {
         use ultraviolet::Vec3x4;
         bench_unop_wide!(b, size, width => 4, op => normalized, ty => Vec3x4)
     });
-    bench_nalgebra_f32x4!(group, |b| {
+    bench_nalgebra_f32x4!(group, size, |b, size| {
         use nalgebra::Vector3;
         use simba::simd::f32x4;
         bench_unop_wide!(b, size, width => 4, op => normalize, ty => Vector3<f32x4>)
     });
-    bench_ultraviolet_f32x8!(group, |b| {
+    bench_ultraviolet_f32x8!(group, size, |b, size| {
         use ultraviolet::Vec3x8;
         bench_unop_wide!(b, size, width => 8, op => normalized, ty => Vec3x8)
     });
-    bench_nalgebra_f32x8!(group, |b| {
+    bench_nalgebra_f32x8!(group, size, |b, size| {
         use nalgebra::Vector3;
         use simba::simd::f32x8;
         bench_unop_wide!(b, size, width => 8, op => normalize, ty => Vector3<f32x8>)
@@ -219,27 +220,27 @@ fn bench_vector3_dot(c: &mut Criterion) {
 }
 
 fn bench_vector3_dot_wide(c: &mut Criterion) {
-    let size = &macros::MIN_WIDE_BENCH_SIZE;
+    let size = &MIN_WIDE_BENCH_SIZE;
     let mut group = c.benchmark_group("wide vector3 dot");
     group.throughput(criterion::Throughput::Elements(*size));
-    bench_glam_f32x1!(group, |b| {
+    bench_glam_f32x1!(group, size, |b, size| {
         use glam::Vec3A;
         bench_binop_wide!(b, size, width => 1, op => dot, ty1 => Vec3A, ty2 => Vec3A)
     });
-    bench_ultraviolet_f32x4!(group, |b| {
+    bench_ultraviolet_f32x4!(group, size, |b, size| {
         use ultraviolet::Vec3x4;
         bench_binop_wide!(b, size, width => 4, op => dot, ty1 => Vec3x4, ty2 => Vec3x4)
     });
-    bench_nalgebra_f32x4!(group, |b| {
+    bench_nalgebra_f32x4!(group, size, |b, size| {
         use nalgebra::Vector3;
         use simba::simd::f32x4;
         bench_binop_wide!(b, size, width => 4, op => dot, ty1 => Vector3<f32x4>, ty2 => Vector3<f32x4>, param => by_ref)
     });
-    bench_ultraviolet_f32x8!(group, |b| {
+    bench_ultraviolet_f32x8!(group, size, |b, size| {
         use ultraviolet::Vec3x8;
         bench_binop_wide!(b, size, width => 8, op => dot, ty1 => Vec3x8, ty2 => Vec3x8)
     });
-    bench_nalgebra_f32x8!(group, |b| {
+    bench_nalgebra_f32x8!(group, size, |b, size| {
         use nalgebra::Vector3;
         use simba::simd::f32x8;
         bench_binop_wide!(b, size, width => 8, op => dot, ty1 => Vector3<f32x8>, ty2 => Vector3<f32x8>, param => by_ref)
@@ -281,27 +282,27 @@ fn bench_vector3_cross(c: &mut Criterion) {
 }
 
 fn bench_vector3_cross_wide(c: &mut Criterion) {
-    let size = &macros::MIN_WIDE_BENCH_SIZE;
+    let size = &MIN_WIDE_BENCH_SIZE;
     let mut group = c.benchmark_group("wide vector3 cross");
     group.throughput(criterion::Throughput::Elements(*size));
-    bench_glam_f32x1!(group, |b| {
+    bench_glam_f32x1!(group, size, |b, size| {
         use glam::Vec3A;
         bench_binop_wide!(b, size, width => 1, op => cross, ty1 => Vec3A, ty2 => Vec3A)
     });
-    bench_ultraviolet_f32x4!(group, |b| {
+    bench_ultraviolet_f32x4!(group, size, |b, size| {
         use ultraviolet::Vec3x4;
         bench_binop_wide!(b, size, width => 4, op => cross, ty1 => Vec3x4, ty2 => Vec3x4)
     });
-    bench_nalgebra_f32x4!(group, |b| {
+    bench_nalgebra_f32x4!(group, size, |b, size| {
         use nalgebra::Vector3;
         use simba::simd::f32x4;
         bench_binop_wide!(b, size, width => 4, op => cross, ty1 => Vector3<f32x4>, ty2 => Vector3<f32x4>, param => by_ref)
     });
-    bench_ultraviolet_f32x8!(group, |b| {
+    bench_ultraviolet_f32x8!(group, size, |b, size| {
         use ultraviolet::Vec3x8;
         bench_binop_wide!(b, size, width => 8, op => cross, ty1 => Vec3x8, ty2 => Vec3x8)
     });
-    bench_nalgebra_f32x8!(group, |b| {
+    bench_nalgebra_f32x8!(group, size, |b, size| {
         use nalgebra::Vector3;
         use simba::simd::f32x8;
         bench_binop_wide!(b, size, width => 8, op => cross, ty1 => Vector3<f32x8>, ty2 => Vector3<f32x8>, param => by_ref)

--- a/scripts/summary.py
+++ b/scripts/summary.py
@@ -14,6 +14,9 @@ WIDE = ['glam_f32x1', 'ultraviolet_f32x4', 'nalgebra_f32x4', 'ultraviolet_f32x8'
 
 CHOICES = SCALAR + WIDE
 
+SCALAR_PREFIX = 'scalar '
+WIDE_PREFIX = 'wide '
+
 class DefaultListAction(argparse.Action):
     def __call__(self, parser, namespace, values, option_string=None):
         if values:
@@ -45,6 +48,7 @@ def parse_bench(json_dir, benches):
             benchmarks = json.load(f)
             bench_name = benchmarks['group_id']
             input_size = benchmarks['value_str']
+
             try:
                 if input_size is not None:
                     bench_name = '{} x{}'.format(bench_name, input_size)
@@ -117,10 +121,10 @@ def main():
     pt = prettytable.PrettyTable(['benchmark'] + [f'  {x:}  ' for x in libs])
     for bench_name in benches:
         if args.wide:
-            if "wide" not in bench_name:
+            if WIDE_PREFIX not in bench_name:
                 continue
         else:
-            if "wide" in bench_name:
+            if WIDE_PREFIX in bench_name:
                 continue
 
         bench = benches[bench_name]
@@ -131,6 +135,13 @@ def main():
         if len(libs) == 1:
             min_value = max_value + 1
         value_strs = [fmt_bench(bench.get(x, None), max_value, min_value, threshold) for x in libs]
+
+        # strip prefix off the bench name for display
+        if bench_name.startswith(SCALAR_PREFIX):
+            bench_name = bench_name[len(SCALAR_PREFIX):]
+        elif bench_name.startswith(WIDE_PREFIX):
+            bench_name = bench_name[len(WIDE_PREFIX):]
+
         pt.add_row([bench_name] + value_strs)
     pt.sortby = 'benchmark'
     pt.align = 'r'

--- a/scripts/summary.py
+++ b/scripts/summary.py
@@ -10,7 +10,7 @@ DEFAULT = ['glam', 'cgmath', 'nalgebra']
 OPTIONAL = ['euclid', 'vek', 'pathfinder', 'static-math', 'ultraviolet']
 SCALAR = DEFAULT + OPTIONAL
 
-WIDE = ['glam', 'ultraviolet_f32x4', 'nalgebra_f32x4', 'ultraviolet_f32x8', 'nalgebra_f32x8']
+WIDE = ['glam_f32x1', 'ultraviolet_f32x4', 'nalgebra_f32x4', 'ultraviolet_f32x8', 'nalgebra_f32x8']
 
 CHOICES = SCALAR + WIDE
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -742,10 +742,10 @@ pub mod static_math_support {
     use static_math::matrix2x2::M22;
     use static_math::matrix3x3::M33;
     use static_math::matrix4x4::M44;
+    use static_math::quaternion::Quaternion;
     use static_math::vector2::V2;
     use static_math::vector3::V3;
     use static_math::vector4::V4;
-    use static_math::quaternion::Quaternion;
 
     fn random_nonzero_f32<R>(rng: &mut R) -> f32
     where


### PR DESCRIPTION
Also name `glam` as `glam_f32x1` in wide benchmarks to hopefully make it clearer that this is scalar for comparison.

I still need to add a bit more info to the README about running these benchmarks.