### PR TITLE
Fix deprecated and redundant semicolons warnings

### DIFF
--- a/benches/eulerbench.rs
+++ b/benches/eulerbench.rs
@@ -11,7 +11,7 @@ macro_rules! bench_euler {
             acc: Vec<$t>,
             vel: Vec<$t>,
             pos: Vec<$t>,
-        };
+        }
 
         let mut rng = rand_pcg::Pcg64Mcg::new(rand::random());
         let mut data = TestData {

--- a/benches/ray_sphere_intersect.rs
+++ b/benches/ray_sphere_intersect.rs
@@ -11,7 +11,7 @@ macro_rules! bench_intersection_wide_uv {
         struct TestData {
             ray_d: Vec<$t>,
             result: Vec<$wt>,
-        };
+        }
 
         let mut rng = rand_pcg::Pcg64Mcg::new(rand::random());
         let ray_d = (0..*$size)
@@ -64,7 +64,7 @@ macro_rules! bench_intersection_wide_na {
         struct TestData {
             ray_d: Vec<$t>,
             result: Vec<$wt>,
-        };
+        }
 
         let mut rng = rand_pcg::Pcg64Mcg::new(rand::random());
         let ray_d = (0..*$size)
@@ -116,7 +116,7 @@ macro_rules! bench_intersection_scalar {
         struct TestData {
             ray_d: Vec<$t>,
             result: Vec<f32>,
-        };
+        }
 
         let mut rng = rand_pcg::Pcg64Mcg::new(rand::random());
         let ray_d = (0..*$size)

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -148,8 +148,8 @@ impl FloatCompare for Mat2 {
     #[inline]
     fn abs_diff(&self, other: &Mat2) -> Mat2 {
         Mat2::from_cols(
-            (self.x_axis() - other.x_axis()).abs(),
-            (self.y_axis() - other.y_axis()).abs(),
+            (self.x_axis - other.x_axis).abs(),
+            (self.y_axis - other.y_axis).abs(),
         )
     }
 }
@@ -162,9 +162,9 @@ impl FloatCompare for Mat3 {
     #[inline]
     fn abs_diff(&self, other: &Mat3) -> Mat3 {
         Mat3::from_cols(
-            (self.x_axis() - other.x_axis()).abs(),
-            (self.y_axis() - other.y_axis()).abs(),
-            (self.z_axis() - other.z_axis()).abs(),
+            (self.x_axis - other.x_axis).abs(),
+            (self.y_axis - other.y_axis).abs(),
+            (self.z_axis - other.z_axis).abs(),
         )
     }
 }
@@ -177,10 +177,10 @@ impl FloatCompare for Mat4 {
     #[inline]
     fn abs_diff(&self, other: &Mat4) -> Mat4 {
         Mat4::from_cols(
-            (self.x_axis() - other.x_axis()).abs(),
-            (self.y_axis() - other.y_axis()).abs(),
-            (self.z_axis() - other.z_axis()).abs(),
-            (self.w_axis() - other.w_axis()).abs(),
+            (self.x_axis - other.x_axis).abs(),
+            (self.y_axis - other.y_axis).abs(),
+            (self.z_axis - other.z_axis).abs(),
+            (self.w_axis - other.w_axis).abs(),
         )
     }
 }


### PR DESCRIPTION
I've been using this project to check the performance of my crate [`vectrix`](https://github.com/rossmacarthur/vectrix) (I might submit a PR for it sometime) and I noticed these warnings.