### PR TITLE
Fix static-math randomization

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -773,7 +773,7 @@ pub mod static_math_support {
     where
         R: Rng,
     {
-        rng.gen_range(0.1, 1.0)
+        rng.gen_range(0.1..1.0)
     }
 
     impl BenchValue for M22<f32> {


### PR DESCRIPTION
Sorry, I missed this at first and forgot to push the fix.